### PR TITLE
Corrected docstrings to explain away bug - exposed parameter to allow…

### DIFF
--- a/dwave/samplers/tabu/sampler.py
+++ b/dwave/samplers/tabu/sampler.py
@@ -31,7 +31,7 @@ class TabuSampler(dimod.Sampler, dimod.Initialized):
     `Tabu search <https://en.wikipedia.org/wiki/Tabu_search>`_ is a heuristic that
     employs local search and can escape local minima by maintaining a "tabu list" of
     recently explored states that it does not revisit. This sampler implements the
-    `MST2 multistart tabu search algorithm with alpha=0.4, lambda=5000.
+    `MST2 multistart tabu search algorithm.
     <https://link.springer.com/article/10.1023/B:ANOR.0000039522.58036.68>`_
     for quadratic unconstrained binary optimization (QUBO) problems.
 
@@ -128,30 +128,29 @@ class TabuSampler(dimod.Sampler, dimod.Initialized):
 
             num_restarts:
                 Maximum number of tabu search restarts per read. Setting this value
-                to zero results in a simple tabu search.
+                to zero results in a simple tabu search. 
 
             energy_threshold:
                 Terminate when an energy lower than or equal to ``energy_threshold`` is found.
 
             coefficient_z_first:
                 :code:`max(bqm.num_variables*coefficient_z_first, lower_bound_z)`
-                determines the number of variable updates considered in the first 
-                simple tabu search. This excludes updates triggered as part of 
-                the LOCAL_SEARCH() subroutine. The coefficient is default as
-                10000 for small problems (num_var<=500) and 25000 for larger 
-                problems.
+                bounds the number of variable updates considered in
+                the first simple tabu search (STS). Variable updates arising from 
+                the STS greedy-descent subroutine, invoked upon discovery of new 
+                global optima, are excluded from the count. The 
+                coefficient defaults to 10000 for small problems (up to 500 
+                variables) and 25000 for larger problems.
                 
             coefficient_z_restart:
-                :code:`max(bqm.num_variables*coefficient_z_restart, lower_bound_z)` 
-                determines the maximum number of variable updates considered in 
-                restarted simple tabu search. This excludes updates triggered as part
-                of the LOCAL_SEARCH() subroutine. The value is defaulted as 
-                :code:`coefficient_z_first/4`
+                Controls the number of variable updates on restarted simple tabu
+                search stages, matching the description for ``coefficient_z_first``. 
+                The coefficient defaults to :code:`coefficient_z_first/4`
                 
             lower_bound_z:
-                Minimum number of updates considered in the simple-tabu search,
-                excluding updates triggered by the LOCAL_SEACH() subroutine. The
-                value is defaulted as 500000. 
+                Sets a minimum number of variable updates on all simple tabu
+                searches, see ``coefficient_z_first``. The bound defaults to 
+                500000. 
 
         Examples:
             This example samples a simple two-variable Ising model.

--- a/dwave/samplers/tabu/src/tabu_search.cpp
+++ b/dwave/samplers/tabu/src/tabu_search.cpp
@@ -29,9 +29,9 @@ TabuSearch::TabuSearch(vector<vector<double>> Q,
                        int numRestarts,
                        unsigned int seed,
                        double energyThreshold,
-                       int Z1Coeff,
-                       int Z2Coeff,
-                       int tabuIterationsLowerBound) 
+                       int coeffZFirst,
+                       int coeffZRestart,
+                       int lowerBoundZ) 
     : bqp(Q) {
     
     size_t nvars = Q.size();
@@ -51,8 +51,8 @@ TabuSearch::TabuSearch(vector<vector<double>> Q,
     generator.seed(seed);
 
     // Solve and update bqp
-    multiStartTabuSearch(timeout, numRestarts, energyThreshold, Z1Coeff, Z2Coeff,
-                         tabuIterationsLowerBound, initSol, nullptr);
+    multiStartTabuSearch(timeout, numRestarts, energyThreshold, coeffZFirst, coeffZRestart,
+                         lowerBoundZ, initSol, nullptr);
 }
 
 double TabuSearch::bestEnergy()
@@ -73,9 +73,9 @@ int TabuSearch::numRestarts()
 void TabuSearch::multiStartTabuSearch(long long timeLimitInMilliSecs, 
                                       int numRestarts, 
                                       double energyThreshold,
-                                      int Z1Coeff,
-                                      int Z2Coeff,
-                                      int tabuIterationsLowerBound,
+                                      int coeffZFirst,
+                                      int coeffZRestart,
+                                      int lowerBoundZ,
                                       const vector<int> &initSolution, 
                                       const bqpSolver_Callback *callback) {
 
@@ -85,17 +85,17 @@ void TabuSearch::multiStartTabuSearch(long long timeLimitInMilliSecs,
 
     // Z coefficents are used to define the max number of iterations for each
     // individual tabu search
-    // Subject to a lower bound of tabuIterationsLowerBound.
+    // Subject to a lower bound of lowerBoundZ.
     // Negative values are used as a flag to indicate defaulting. 
-    if(Z1Coeff < 0)
-        Z1Coeff = (bqp.nVars <= 500)? 10000 : 25000;
-    if(Z2Coeff < 0)
-        // Previous default simplified: Z2Coeff = (bqp.nVars <= 500)? 2500 : 10000;
-        Z2Coeff = Z1Coeff/4;
-    if(tabuIterationsLowerBound<0)
-        tabuIterationsLowerBound = 500000;
-    long long maxIterInitialSearch = (tabuIterationsLowerBound > Z1Coeff * (long long)bqp.nVars) ? tabuIterationsLowerBound : Z1Coeff * (long long)bqp.nVars;
-    long long maxIterRestartedSearch = (tabuIterationsLowerBound > Z2Coeff * (long long)bqp.nVars) ? tabuIterationsLowerBound : Z2Coeff * (long long)bqp.nVars;
+    if(coeffZFirst < 0)
+        coeffZFirst = (bqp.nVars <= 500)? 10000 : 25000;
+    if(coeffZRestart < 0)
+        // Previous default simplified: coeffZRestart = (bqp.nVars <= 500)? 2500 : 10000;
+        coeffZRestart = coeffZFirst/4;
+    if(lowerBoundZ<0)
+        lowerBoundZ = 500000;
+    long long maxIterInitialSearch = (lowerBoundZ > coeffZFirst * (long long)bqp.nVars) ? lowerBoundZ : coeffZFirst * (long long)bqp.nVars;
+    long long maxIterRestartedSearch = (lowerBoundZ > coeffZRestart * (long long)bqp.nVars) ? lowerBoundZ : coeffZRestart * (long long)bqp.nVars;
     bqp.initialize(initSolution);
 
     bool useTimeLimit = timeLimitInMilliSecs >= 0;

--- a/dwave/samplers/tabu/src/tabu_search.cpp
+++ b/dwave/samplers/tabu/src/tabu_search.cpp
@@ -31,7 +31,7 @@ TabuSearch::TabuSearch(vector<vector<double>> Q,
                        double energyThreshold,
                        int Z1Coeff,
                        int Z2Coeff,
-		       int tabuIterationsLowerBound) 
+                       int tabuIterationsLowerBound) 
     : bqp(Q) {
     
     size_t nvars = Q.size();
@@ -73,9 +73,9 @@ int TabuSearch::numRestarts()
 void TabuSearch::multiStartTabuSearch(long long timeLimitInMilliSecs, 
                                       int numRestarts, 
                                       double energyThreshold,
-				      int Z1Coeff,
-				      int Z2Coeff,
-				      int tabuIterationsLowerBound,
+                                      int Z1Coeff,
+                                      int Z2Coeff,
+                                      int tabuIterationsLowerBound,
                                       const vector<int> &initSolution, 
                                       const bqpSolver_Callback *callback) {
 
@@ -131,9 +131,9 @@ void TabuSearch::multiStartTabuSearch(long long timeLimitInMilliSecs,
         selectVariables(numSelection, C, I);  
 
         // Construct new initial solution to apply taboo search to
-	vector<int> solution (bqp.nVars);
+        vector<int> solution (bqp.nVars);
         steepestAscent(numSelection, C, I, solution); 
-	
+
         for (int i = 0; i < numSelection; i++) {
             if (solution[I[i]] == 1) {
                 bqp.solution[I[i]] = 1 - bqp.solution[I[i]];  // flipping variable
@@ -341,8 +341,8 @@ void TabuSearch::selectVariables(int numSelection, vector<vector<double>> &C, ve
                     continue;
                 }
                 if (d[i] <= 0 && dmin < 0) {
-		    // Default lambda is large, d[i]
-		    // selected only after exhausing positive d[i]
+                    // Default lambda is large, d[i]
+                    // selected only after exhausing positive d[i]
                     e[i] = 1 - d[i] / dmin;
                 }
                 else if (d[i] == dmin && dmin == 0) {

--- a/dwave/samplers/tabu/src/tabu_search.cpp
+++ b/dwave/samplers/tabu/src/tabu_search.cpp
@@ -29,8 +29,8 @@ TabuSearch::TabuSearch(vector<vector<double>> Q,
                        int numRestarts,
                        unsigned int seed,
                        double energyThreshold,
-		       int Z1Coeff,
-		       int Z2Coeff,
+                       int Z1Coeff,
+                       int Z2Coeff,
 		       int tabuIterationsLowerBound) 
     : bqp(Q) {
     
@@ -52,7 +52,7 @@ TabuSearch::TabuSearch(vector<vector<double>> Q,
 
     // Solve and update bqp
     multiStartTabuSearch(timeout, numRestarts, energyThreshold, Z1Coeff, Z2Coeff,
-			 tabuIterationsLowerBound, initSol, nullptr);
+                         tabuIterationsLowerBound, initSol, nullptr);
 }
 
 double TabuSearch::bestEnergy()

--- a/dwave/samplers/tabu/src/tabu_search.h
+++ b/dwave/samplers/tabu/src/tabu_search.h
@@ -37,7 +37,10 @@ class TabuSearch
                    long int timeout, 
                    int numRestarts, 
                    unsigned int seed, 
-                   double energyThreshold);
+                   double energyThreshold,
+		   int Z1coeff,
+		   int Z2coeff,
+		   int tabuIterationsLowerBound);
         double bestEnergy();
         std::vector<int> bestSolution();
         int numRestarts();
@@ -47,7 +50,7 @@ class TabuSearch
          * Simple tabu search solver with multi starts. Updates bqp with best solution found.
          * \param timeLimitInMilliSecs: Time limit in milliseconds
          * \param numStarts: Number of re starts
-         * \param energyThreshold: Search terminates when energy lower than threshold is found
+         * \param energyThreshold: Search terminates when energy equal to or lower than threshold is found
          * \param initSolution: Starting solution to start search from
          * \param callback: Optional callback function
          * \return
@@ -55,6 +58,9 @@ class TabuSearch
         void multiStartTabuSearch(long long timeLimitInMilliSecs, 
                                   int numStarts, 
                                   double energyThreshold,
+				  int Z1coeff,
+				  int Z2coeff,
+				  int tabuIterationsLowerBound,
                                   const std::vector<int> &initSolution, 
                                   const bqpSolver_Callback *callback);
 
@@ -62,10 +68,12 @@ class TabuSearch
          * Solves and updates the BQP using simple tabu search heuristic
          * \param starting: A starting solution
          * \param startingObjective: The objective function value for the starting solution
-         * \param ZCoeff: Parameter used to define the max number of iterations
+         * \param Z1Coeff: Parameter used to define the number of iterations on first STS
+         * \param Z2Coeff: Parameter used to define the number of iterations on subsequent STS
+         * \param tabuIterationsLowerBound: Parameter used to define a minimum number of updates per STS procedure
          * \param timeLimitInMilliSecs: Time limit in milli seconds
          * \param useTimeLimit: If false, timeLimitInMilliSecs is ignored
-         * \param energyThreshold: Search terminates when energy lower than threshold is found
+         * \param energyThreshold: Search terminates when energy lower than or equal to the threshold is found
          * \param callback: Optional callback function
          * \return
          */

--- a/dwave/samplers/tabu/src/tabu_search.h
+++ b/dwave/samplers/tabu/src/tabu_search.h
@@ -38,9 +38,9 @@ class TabuSearch
                    int numRestarts, 
                    unsigned int seed, 
                    double energyThreshold,
-                   int Z1coeff,
-                   int Z2coeff,
-                   int tabuIterationsLowerBound);
+                   int coeffZFirst,
+                   int coeffZRestart,
+                   int lowerBoundZ);
         double bestEnergy();
         std::vector<int> bestSolution();
         int numRestarts();
@@ -51,6 +51,9 @@ class TabuSearch
          * \param timeLimitInMilliSecs: Time limit in milliseconds
          * \param numStarts: Number of re starts
          * \param energyThreshold: Search terminates when energy equal to or lower than threshold is found
+         * \param coeffZFirst: Parameter used to define the number of iterations on first STS
+         * \param coeffZRestart: Parameter used to define the number of iterations on subsequent STS
+         * \param lowerBoundZ: Parameter used to define a minimum number of updates per STS procedure
          * \param initSolution: Starting solution to start search from
          * \param callback: Optional callback function
          * \return
@@ -58,9 +61,9 @@ class TabuSearch
         void multiStartTabuSearch(long long timeLimitInMilliSecs, 
                                   int numStarts, 
                                   double energyThreshold,
-                                  int Z1coeff,
-                                  int Z2coeff,
-                                  int tabuIterationsLowerBound,
+                                  int coeffZFirst,
+                                  int coeffZRestart,
+                                  int lowerBoundZ,
                                   const std::vector<int> &initSolution, 
                                   const bqpSolver_Callback *callback);
 
@@ -68,12 +71,12 @@ class TabuSearch
          * Solves and updates the BQP using simple tabu search heuristic
          * \param starting: A starting solution
          * \param startingObjective: The objective function value for the starting solution
-         * \param Z1Coeff: Parameter used to define the number of iterations on first STS
-         * \param Z2Coeff: Parameter used to define the number of iterations on subsequent STS
-         * \param tabuIterationsLowerBound: Parameter used to define a minimum number of updates per STS procedure
          * \param timeLimitInMilliSecs: Time limit in milli seconds
          * \param useTimeLimit: If false, timeLimitInMilliSecs is ignored
          * \param energyThreshold: Search terminates when energy lower than or equal to the threshold is found
+         * \param coeffZFirst: Parameter used to define the number of iterations on first STS
+         * \param coeffZRestart: Parameter used to define the number of iterations on subsequent STS
+         * \param lowerBoundZ: Parameter used to define a minimum number of updates per STS procedure
          * \param callback: Optional callback function
          * \return
          */

--- a/dwave/samplers/tabu/src/tabu_search.h
+++ b/dwave/samplers/tabu/src/tabu_search.h
@@ -38,9 +38,9 @@ class TabuSearch
                    int numRestarts, 
                    unsigned int seed, 
                    double energyThreshold,
-		   int Z1coeff,
-		   int Z2coeff,
-		   int tabuIterationsLowerBound);
+                   int Z1coeff,
+                   int Z2coeff,
+                   int tabuIterationsLowerBound);
         double bestEnergy();
         std::vector<int> bestSolution();
         int numRestarts();
@@ -58,9 +58,9 @@ class TabuSearch
         void multiStartTabuSearch(long long timeLimitInMilliSecs, 
                                   int numStarts, 
                                   double energyThreshold,
-				  int Z1coeff,
-				  int Z2coeff,
-				  int tabuIterationsLowerBound,
+                                  int Z1coeff,
+                                  int Z2coeff,
+                                  int tabuIterationsLowerBound,
                                   const std::vector<int> &initSolution, 
                                   const bqpSolver_Callback *callback);
 

--- a/dwave/samplers/tabu/tabu.pxd
+++ b/dwave/samplers/tabu/tabu.pxd
@@ -24,9 +24,9 @@ cdef extern from "tabu_search.h" nogil:
                    int numRestarts,
                    unsigned int seed,
                    double energyThreshold,
-		   double Z1coeff,
-		   double Z2coeff,
-		   double tabuIterationsLowerBound) except +
+		   int coeffZFirst,
+		   int coeffZRestart,
+		   int lowerBoundZ) except +
         double bestEnergy()
         vector[int] bestSolution()
         int numRestarts()

--- a/dwave/samplers/tabu/tabu.pxd
+++ b/dwave/samplers/tabu/tabu.pxd
@@ -23,7 +23,10 @@ cdef extern from "tabu_search.h" nogil:
                    long int timeout,
                    int numRestarts,
                    unsigned int seed,
-                   double energyThreshold) except +
+                   double energyThreshold,
+		   double Z1coeff,
+		   double Z2coeff,
+		   double tabuIterationsLowerBound) except +
         double bestEnergy()
         vector[int] bestSolution()
         int numRestarts()

--- a/dwave/samplers/tabu/tabu_search.pyx
+++ b/dwave/samplers/tabu/tabu_search.pyx
@@ -35,9 +35,15 @@ cdef class TabuSearch:
                   int timeout,
                   int numRestarts,
                   object seed=None,
-                  object energyThreshold=None):
+                  object energyThreshold=None,
+                  object Z1coeff=None,
+                  object Z2coeff=None,
+                  object tabuIterationsLowerBound=None):
         cdef unsigned int _seed = time(NULL) if seed is None else seed
         cdef double _energyThreshold = -np.inf if energyThreshold is None else energyThreshold
+        cdef int _Z1coeff = -1 if Z1coeff is None else Z1coeff
+        cdef int _Z2coeff = -1 if Z2coeff is None else Z2coeff
+        cdef int _tabuIterationsLowerBound = -1 if tabuIterationsLowerBound is None else tabuIterationsLowerBound
 
         cdef double[:,:] qubo = np.asarray(Q, dtype=np.double)
         cdef vector[vector[double]] Qvec
@@ -54,7 +60,8 @@ cdef class TabuSearch:
 
         with nogil:
             self.c_tabu = new dwave.samplers.tabu.tabu.TabuSearch(
-                Qvec, initVec, tenure, timeout, numRestarts, _seed, _energyThreshold)
+                Qvec, initVec, tenure, timeout, numRestarts, _seed, _energyThreshold,
+                _Z1coeff, _Z2coeff, _tabuIterationsLowerBound)
 
     def __dealloc__(self):
         del self.c_tabu

--- a/dwave/samplers/tabu/tabu_search.pyx
+++ b/dwave/samplers/tabu/tabu_search.pyx
@@ -36,14 +36,14 @@ cdef class TabuSearch:
                   int numRestarts,
                   object seed=None,
                   object energyThreshold=None,
-                  object Z1coeff=None,
-                  object Z2coeff=None,
-                  object tabuIterationsLowerBound=None):
+                  object coeffZFirst=None,
+                  object coeffZRestart=None,
+                  object lowerBoundZ=None):
         cdef unsigned int _seed = time(NULL) if seed is None else seed
         cdef double _energyThreshold = -np.inf if energyThreshold is None else energyThreshold
-        cdef int _Z1coeff = -1 if Z1coeff is None else Z1coeff
-        cdef int _Z2coeff = -1 if Z2coeff is None else Z2coeff
-        cdef int _tabuIterationsLowerBound = -1 if tabuIterationsLowerBound is None else tabuIterationsLowerBound
+        cdef int _coeffZFirst = -1 if coeffZFirst is None else coeffZFirst
+        cdef int _coeffZRestart = -1 if coeffZRestart is None else coeffZRestart
+        cdef int _lowerBoundZ = -1 if lowerBoundZ is None else lowerBoundZ
 
         cdef double[:,:] qubo = np.asarray(Q, dtype=np.double)
         cdef vector[vector[double]] Qvec
@@ -61,7 +61,7 @@ cdef class TabuSearch:
         with nogil:
             self.c_tabu = new dwave.samplers.tabu.tabu.TabuSearch(
                 Qvec, initVec, tenure, timeout, numRestarts, _seed, _energyThreshold,
-                _Z1coeff, _Z2coeff, _tabuIterationsLowerBound)
+                _coeffZFirst, _coeffZRestart, _lowerBoundZ)
 
     def __dealloc__(self):
         del self.c_tabu

--- a/tests/test_tabu_sampler.py
+++ b/tests/test_tabu_sampler.py
@@ -238,6 +238,12 @@ class TestTabuSampler(unittest.TestCase):
             response = sampler.sample(bqm, num_reads=3, timeout=200, seed=123)
         self.assertAlmostEqual(tt.dt, 0.6, places=1)
 
+        #Run as simple-tabu-search with timeout:
+        with tictoc() as tt:
+            response = sampler.sample(bqm, num_reads=2, timeout=300, seed=123,
+                                      num_restarts=0, lower_bound_z= 2147483647)
+        self.assertAlmostEqual(tt.dt, 0.6, places=1)
+
     def test_num_restarts(self):
         sampler = tabu.TabuSampler()
         bqm = dimod.generators.random.randint(10, 'SPIN', seed=123)
@@ -258,3 +264,44 @@ class TestTabuSampler(unittest.TestCase):
             response = sampler.sample(bqm, timeout=100000, energy_threshold=energy_threshold, seed=345)
 
         self.assertLessEqual(tt.dt, 1.0)
+
+    def test_coeff_z(self):
+        # bqm with excited state initialization should relax if and only if updated:
+        # num_var large enough that 'steepest ascent' subroutine does not cover all variables:
+        num_var = 11
+        bqm = dimod.BinaryQuadraticModel.from_ising({i : 1 for i in range(num_var)},{})
+        init = dimod.SampleSet.from_samples_bqm([{i: bqm.linear[i] for i in range(num_var)}], bqm)
+        #Energy +1 initialization:
+        initM = dimod.SampleSet.from_samples_bqm([{i: bqm.linear[i] if i>=num_var/2 else -bqm.linear[i] for i in range(num_var)}], bqm)
+        sampler = tabu.TabuSampler()
+        
+        response = sampler.sample(bqm, num_reads=1, timeout=None, num_restarts=0,
+                                  coefficient_z_first=0, lower_bound_z=0,
+                                  initial_states=init)
+        self.assertEqual(response.record.energy[0], num_var) #No updates, sufficient to find global minima.
+        
+        response = sampler.sample(bqm, num_reads=1, timeout=None, num_restarts=0,
+                                  coefficient_z_first=0, lower_bound_z=1,
+                                  initial_states=init)
+        self.assertEqual(response.record.energy[0], -num_var) #Updated once, sufficient to find global minima.
+        
+        response = sampler.sample(bqm, num_reads=1, timeout=None, num_restarts=0,
+                                  coefficient_z_first=1, lower_bound_z=0,
+                                  initial_states=init)
+        self.assertEqual(response.record.energy[0], -num_var) #Updated once, sufficient to find global minima.
+
+        response = sampler.sample(bqm, num_reads=1, timeout=None, num_restarts=1,
+                                  coefficient_z_first=0, lower_bound_z=0,
+                                  coefficient_z_restart=1, 
+                                  initial_states=init)
+        self.assertEqual(response.record.energy[0], -num_var) #Updated once, sufficient to find global minima.
+        
+        # subset steepest ascent (meaning descent, if we think of qubo minimization)
+        # alone is insufficient to establish local minima:        
+        response = sampler.sample(bqm, num_reads=1, timeout=None, num_restarts=1,
+                                  coefficient_z_first=0, lower_bound_z=0,
+                                  coefficient_z_restart=0, 
+                                  initial_states=init)
+        self.assertLess(response.record.energy[0], num_var)
+        self.assertGreater(response.record.energy[0], -num_var)
+

--- a/tests/test_tabu_sampler.py
+++ b/tests/test_tabu_sampler.py
@@ -268,17 +268,17 @@ class TestTabuSampler(unittest.TestCase):
     def test_coeff_z(self):
         # bqm with excited state initialization should relax if and only if updated:
         # num_var large enough that 'steepest ascent' subroutine does not cover all variables:
+        # single spin model (trivially solved by MIS), with initialization in
+        # an excited state
         num_var = 11
         bqm = dimod.BinaryQuadraticModel.from_ising({i : 1 for i in range(num_var)},{})
         init = dimod.SampleSet.from_samples_bqm([{i: bqm.linear[i] for i in range(num_var)}], bqm)
-        #Energy +1 initialization:
-        initM = dimod.SampleSet.from_samples_bqm([{i: bqm.linear[i] if i>=num_var/2 else -bqm.linear[i] for i in range(num_var)}], bqm)
         sampler = tabu.TabuSampler()
         
         response = sampler.sample(bqm, num_reads=1, timeout=None, num_restarts=0,
                                   coefficient_z_first=0, lower_bound_z=0,
                                   initial_states=init)
-        self.assertEqual(response.record.energy[0], num_var) #No updates, sufficient to find global minima.
+        self.assertEqual(response.record.energy[0], num_var) #No updates, insufficient to find global minima.
         
         response = sampler.sample(bqm, num_reads=1, timeout=None, num_restarts=0,
                                   coefficient_z_first=0, lower_bound_z=1,
@@ -297,7 +297,8 @@ class TestTabuSampler(unittest.TestCase):
         self.assertEqual(response.record.energy[0], -num_var) #Updated once, sufficient to find global minima.
         
         # subset steepest ascent (meaning descent, if we think of qubo minimization)
-        # alone is insufficient to establish local minima:        
+        # alone is insufficient to establish global minima, but is sufficient to
+        # escape the global maxima:        
         response = sampler.sample(bqm, num_reads=1, timeout=None, num_restarts=1,
                                   coefficient_z_first=0, lower_bound_z=0,
                                   coefficient_z_restart=0, 


### PR DESCRIPTION
Pull request closes bug:
https://github.com/dwavesystems/dwave-samplers/issues/25

Docstrings are altered to reflect that certain parameters are bounds rather than approximations, and other minor corrections. The bug is a documentation error, timeout only sets an upper bound on the time used, actual time used is controlled by a combination of hidden parameters, num_restarts and num_reads.

I have exposed three new parameters. By setting an effectively infinite value for zmax (number of spin updates), the timeout can now be used to better (though still imperfectly) control wallclock runtime. 
`samples = tabu_sampler.sample_ising(h = {'a': -0.5, 'b': 1.0}, J = {'ab ': -1},num_restarts = 0,num_reads=100,timeout=1000, lower_bound_z = 2147483648)`

This satisfies my use case and solves the bug, but I would like to a couple of other things in a similar vein: expose lambda and alpha parameters through the wrapper;  and allow timeout control of the STS subroutines (complementing zmax control). 