### PR TITLE
Allow num_sweeps=0 for simulated annealing.

### DIFF
--- a/dwave/samplers/sa/sampler.py
+++ b/dwave/samplers/sa/sampler.py
@@ -335,8 +335,8 @@ class SimulatedAnnealingSampler(dimod.Sampler, dimod.Initialized):
 
             num_betas, rem = divmod(num_sweeps,num_sweeps_per_beta)
 
-            if rem > 0 or num_betas < 1:
-                error_msg = "'num_sweeps' must be a positive value divisible by 'num_sweeps_per_beta'."
+            if rem > 0 or num_betas < 0:
+                error_msg = "'num_sweeps' must be a non-negative value divisible by 'num_sweeps_per_beta'."
                 raise ValueError(error_msg)
 
             if beta_range is None:

--- a/releasenotes/notes/0-sweeps-neal-c15e16e6a9891bfd.yaml
+++ b/releasenotes/notes/0-sweeps-neal-c15e16e6a9891bfd.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Allow ``num_sweeps=0`` for simulated annealing. This was incorrectly
+    disabled in ``1.0.0.dev0``.

--- a/tests/test_simulated_annealing_sampler.py
+++ b/tests/test_simulated_annealing_sampler.py
@@ -316,6 +316,25 @@ class TestSimulatedAnsaingSampler(unittest.TestCase):
         # if num_reads explicitly given together without initial_states, they are generated
         self.assertEqual(len(sampler.sample(bqm, num_reads=4)), 4)
 
+    def test_0_num_sweeps(self):
+        bqm = dimod.BinaryQuadraticModel({}, {'ab': 1}, 0, 'SPIN')
+        sampleset = dimod.SampleSet.from_samples_bqm([{'a': 1, 'b': -1},
+                                                      {'a': -1, 'b': 1}], bqm)
+
+        result = SimulatedAnnealingSampler().sample(bqm, num_sweeps=0, initial_states=sampleset)
+
+        self.assertTrue(np.array_equal(result.record.sample, sampleset.record.sample))
+        self.assertEqual(len(result.record.sample), 2)
+
+        result = SimulatedAnnealingSampler().sample(
+            bqm, num_sweeps=0, num_reads=4,
+            initial_states=sampleset, initial_states_generator='tile')
+
+        expected = np.tile(sampleset.record.sample, (2, 1))
+
+        self.assertTrue(np.array_equal(result.record.sample, expected))
+        self.assertEqual(len(result), 4)
+
 
 class TestDefaultBetaRange(unittest.TestCase):
     def test_empty_problem(self):


### PR DESCRIPTION
Requirement that `num_sweeps` be positive was incorrectly introduced in https://github.com/dwavesystems/dwave-neal/pull/91

See https://github.com/dwavesystems/dwave-ocean-sdk/pull/221