### PR TITLE
Refactor TreeDecompositionSampler tests to use parameterized

### DIFF
--- a/tests/test_tree_sampler.py
+++ b/tests/test_tree_sampler.py
@@ -20,6 +20,7 @@ import unittest
 import dimod
 import numpy as np
 import networkx as nx
+import parameterized
 
 from dwave.samplers.tree import TreeDecompositionSampler
 
@@ -107,7 +108,21 @@ class TestSample(unittest.TestCase):
         dimod.testing.assert_response_energies(samples, bqm)
 
 
-class TestMarginals:
+@parameterized.parameterized_class([
+        dict(bqm=dimod.BinaryQuadraticModel.from_ising({'a': -1}, {})),
+        dict(bqm=dimod.BinaryQuadraticModel.from_ising({'a': +1}, {})),
+        dict(bqm=dimod.BinaryQuadraticModel.from_qubo({(0, 0): -1})),
+        dict(bqm=dimod.BinaryQuadraticModel.from_qubo({(0, 0): +1})),
+        dict(bqm=dimod.BinaryQuadraticModel.from_ising({'a': -1}, {}, .5)),
+        dict(bqm=dimod.BinaryQuadraticModel.from_qubo({(0, 0): -1}, offset=.5)),
+        dict(bqm=dimod.BinaryQuadraticModel.from_ising({}, {'ab': -1})),
+        dict(bqm=dimod.BinaryQuadraticModel.from_ising({}, {'ab': 1})),
+        dict(bqm=dimod.BinaryQuadraticModel.from_ising({}, {'ab': .69, 'bc': 1, 'ac': .5})),
+        dict(bqm=dimod.BinaryQuadraticModel.from_qubo({'ab': .69, 'bc': 1, 'ac': .5})),
+        dict(bqm=dimod.BinaryQuadraticModel.from_qubo({'ab': .69, 'bc': 1})),
+        dict(bqm=dimod.AdjDictBQM({'a': 6.0, 0: 1}, {('a', 0): -3, (0, 'c'): 10}, 0, 'BINARY')),
+])
+class TestMarginals(unittest.TestCase):
     def test_spin_log_partition_function(self):
         bqm = self.bqm
 
@@ -224,59 +239,3 @@ class TestMarginals:
             for pair, combos in interaction_marginals.items():
                 for config, p in combos.items():
                     self.assertAlmostEqual(p, analytic_marginals[pair][config])
-
-
-class TestSingleVariableSPIN(unittest.TestCase, TestMarginals):
-    bqm = dimod.BinaryQuadraticModel.from_ising({'a': -1}, {})
-
-
-class TestSingleVariableSPIN2(unittest.TestCase, TestMarginals):
-    bqm = dimod.BinaryQuadraticModel.from_ising({'a': 1}, {})
-
-
-class TestSingleVariableBINARY(unittest.TestCase, TestMarginals):
-    bqm = dimod.BinaryQuadraticModel.from_qubo({(0, 0): -1})
-
-
-class TestSingleVariableBINARY(unittest.TestCase, TestMarginals):
-    bqm = dimod.BinaryQuadraticModel.from_qubo({(0, 0): 1})
-
-
-class TestSingleVariableWithOffsetSPIN(unittest.TestCase, TestMarginals):
-    bqm = dimod.BinaryQuadraticModel.from_ising({'a': -1}, {}, .5)
-
-
-class TestSingleVariableWithOffsetBINARY(unittest.TestCase, TestMarginals):
-    bqm = dimod.BinaryQuadraticModel.from_qubo({(0, 0): -1}, offset=.5)
-
-
-class TestSingleInteractionSPIN(unittest.TestCase, TestMarginals):
-    bqm = dimod.BinaryQuadraticModel.from_ising({}, {'ab': -1})
-
-
-class TestSingleInteractionSPIN2(unittest.TestCase, TestMarginals):
-    bqm = dimod.BinaryQuadraticModel.from_ising({}, {'ab': 1})
-
-
-class TestK3SPIN(unittest.TestCase, TestMarginals):
-    bqm = dimod.BinaryQuadraticModel.from_ising({}, {'ab': .69, 'bc': 1, 'ac': .5})
-
-
-class TestK3BINARY(unittest.TestCase, TestMarginals):
-    bqm = dimod.BinaryQuadraticModel.from_qubo({'ab': .69, 'bc': 1, 'ac': .5})
-
-
-class Test3pathBINARY(unittest.TestCase, TestMarginals):
-    bqm = dimod.BinaryQuadraticModel.from_qubo({'ab': .69, 'bc': 1})
-
-
-class TestLongerPath(unittest.TestCase, TestMarginals):
-    g = nx.path_graph(10)
-    linear = {node: np.random.randint(-20,20) for node in g.nodes}
-    quadratic = {edge: np.random.randint(-20,20) for edge in g.edges}
-    bqm = dimod.BinaryQuadraticModel(linear, quadratic, "BINARY")
-
-
-class TestDictBQM(unittest.TestCase, TestMarginals):
-    bqm = dimod.AdjDictBQM({'a': 6.0, 0: 1}, {('a', 0): -3, (0, 'c'): 10}, 0, 'BINARY')
-


### PR DESCRIPTION
This allows pytest compatibility, see https://github.com/dwavesystems/dwave-ocean-sdk/pull/247#discussion_r1102960878