### PR TITLE
Fix SimulatedAnnealingSampler.parameters

### DIFF
--- a/dwave/samplers/sa/sampler.py
+++ b/dwave/samplers/sa/sampler.py
@@ -88,17 +88,17 @@ class SimulatedAnnealingSampler(dimod.Sampler, dimod.Initialized):
         >>> for kwarg in sorted(sampler.parameters):
         ...     print(kwarg)
         beta_range
+        beta_schedule
+        beta_schedule_type
+        initial_states
+        initial_states_generator
+        interrupt_function
         num_reads
         num_sweeps
         num_sweeps_per_beta
-        beta_schedule_type
-        beta_schedule
-        seed
-        interrupt_function
-        initial_states
-        initial_states_generator
-        randomize_order
         proposal_acceptance_criteria
+        randomize_order
+        seed
         >>> sampler.parameters['beta_range']
         []
         >>> sampler.parameters['beta_schedule_type']

--- a/dwave/samplers/sa/sampler.py
+++ b/dwave/samplers/sa/sampler.py
@@ -88,14 +88,17 @@ class SimulatedAnnealingSampler(dimod.Sampler, dimod.Initialized):
         >>> for kwarg in sorted(sampler.parameters):
         ...     print(kwarg)
         beta_range
-        beta_schedule_type
-        initial_states
-        initial_states_generator
-        interrupt_function
         num_reads
         num_sweeps
         num_sweeps_per_beta
+        beta_schedule_type
+        beta_schedule
         seed
+        interrupt_function
+        initial_states
+        initial_states_generator
+        randomize_order
+        proposal_acceptance_criteria
         >>> sampler.parameters['beta_range']
         []
         >>> sampler.parameters['beta_schedule_type']
@@ -123,10 +126,13 @@ class SimulatedAnnealingSampler(dimod.Sampler, dimod.Initialized):
                            'num_sweeps': [],
                            'num_sweeps_per_beta': [],
                            'beta_schedule_type': ['beta_schedule_options'],
+                           'beta_schedule': [],
                            'seed': [],
                            'interrupt_function': [],
                            'initial_states': [],
                            'initial_states_generator': [],
+                           'randomize_order': [],
+                           'proposal_acceptance_criteria': [],
                            }
         self.properties = {'beta_schedule_options': ('linear', 'geometric',
                                                      'custom')}

--- a/releasenotes/notes/fix-SA-parameters-d114a63f7371fd7f.yaml
+++ b/releasenotes/notes/fix-SA-parameters-d114a63f7371fd7f.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Add all keyword args of ``SimulatedAnnealingSampler.sample`` to ``SimulatedAnnealingSampler.parameters``. This allows effective use of ``dimod.Sampler.remove_unknown_kwargs``

--- a/tests/test_simulated_annealing_sampler.py
+++ b/tests/test_simulated_annealing_sampler.py
@@ -15,6 +15,7 @@
 import unittest
 import numpy as np
 import copy
+import inspect
 import itertools
 import warnings
 
@@ -93,6 +94,24 @@ class TestSimulatedAnnealingSampler(unittest.TestCase):
     def test_instantiation(self):
         sampler = SimulatedAnnealingSampler()
         dimod.testing.assert_sampler_api(sampler)
+
+    def test_good_kwargs(self):
+        sampler = SimulatedAnnealingSampler()
+        kwargs = dict(inspect.signature(sampler.sample).parameters)
+        kwargs.pop('bqm')
+        kwargs.pop('kwargs')
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore')
+            kwargs_out = sampler.remove_unknown_kwargs(**kwargs)
+        self.assertEqual(kwargs.keys(), kwargs_out.keys(), "Keyword arguments removed")
+
+    def test_bad_kwargs(self):
+        sampler = SimulatedAnnealingSampler()
+        kwargs = {'foobar': None}
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore')
+            kwargs_out = sampler.remove_unknown_kwargs(**kwargs)
+        self.assertFalse(kwargs_out, "Keyword arguments not removed")
 
     def test_one_node_beta_range(self):
         h = {'a': -1}


### PR DESCRIPTION
Complete the list of keyword args in `SimulatedAnnealingSampler.parameters` so that `dimod.Sampler.remove_unknown_kwargs` works correctly