### PR TITLE
Fix CI python env caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -250,9 +250,6 @@ jobs:
     steps:
       - checkout
 
-      - restore_cache:
-          key: v2-dependencies-312-{{ checksum "requirements.txt" }}-{{ checksum "tests/requirements.txt" }}-{{ checksum "docs/requirements.txt" }}-{{ .Environment.CIRCLE_JOB }}
-
       - run:
           name: Create virtual environment
           command: |
@@ -263,11 +260,6 @@ jobs:
           command: |
             . env/bin/activate
             pip install -r requirements.txt -r tests/requirements.txt -r docs/requirements.txt
-
-      - save_cache:
-          key: v2-dependencies-312-{{ checksum "requirements.txt" }}-{{ checksum "tests/requirements.txt" }}-{{ checksum "docs/requirements.txt" }}-{{ .Environment.CIRCLE_JOB }}
-          paths:
-            - env
 
       - run:
           name: run cpp tests


### PR DESCRIPTION
Don't cache python env anymore. The env references the python binary which can change on image update (e.g. python patch release). This breaks the ref, so we would either need to cache the pyenv's python binary, or include the full python version in the cache key. All this makes is not worth the few seconds saved on a fresh env build. And not caching is consistent with other jobs.