### PR TITLE
Release 1.8.0

### DIFF
--- a/dwave/samplers/__init__.py
+++ b/dwave/samplers/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.7.0"
+__version__ = "1.8.0"
 
 from dwave.samplers.greedy import *
 


### PR DESCRIPTION
### New Features

- Build with <span class="title-ref">meson</span> rather than <span class="title-ref">setuptools</span>.

<!-- -->

- Use Python's limited API for Python 3.12+.
