### PR TITLE
Fix duplicate target name in README ReST

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,6 +95,22 @@ jobs:
       - checkout
       - run-cibuildwheel
 
+  check-dist:
+    docker:
+      - image: cimg/python:3.12
+
+    steps:
+      - attach_workspace:
+          at: dist
+
+      - run:
+          name: check package
+          command: |
+            python -m venv env
+            . env/bin/activate
+            python -m pip install twine
+            twine check ./dist/*
+
   deploy-all:
     docker:
       - image: cimg/python:3.12
@@ -256,6 +272,14 @@ workflows:
           filters: *tags
           requires:
             - build-sdist
+      - check-dist:
+          filters: *tags
+          requires:
+            - build-and-test-linux
+            - build-and-test-linux-aarch64
+            - build-and-test-osx
+            - build-and-test-windows
+            - build-sdist
       - deploy-all:
           filters:
             tags:
@@ -268,3 +292,4 @@ workflows:
             - build-and-test-osx
             - build-and-test-windows
             - build-sdist
+            - check-dist

--- a/README.rst
+++ b/README.rst
@@ -84,7 +84,7 @@ Get the best 5 sample found in .1 seconds.
 Simulated Annealing
 -------------------
 
-`Simulated annealing <https://en.wikipedia.org/wiki/Simulated_annealing>`_ can
+`Simulated annealing <https://en.wikipedia.org/wiki/Simulated_annealing>`__ can
 be used for heuristic optimization or approximate Boltzmann sampling. The
 *dwave-samplers* implementation approaches the equilibrium distribution by
 performing updates at a sequence of decreasing temperatures, terminating at the
@@ -147,7 +147,7 @@ Sample projected states from a quantum process with a linear schedule
 Steepest Descent
 ----------------
 
-`Steepest descent <https://en.wikipedia.org/wiki/Gradient_descent>`_ is the
+`Steepest descent <https://en.wikipedia.org/wiki/Gradient_descent>`__ is the
 discrete analogue of gradient descent, but the best move is computed using a
 local minimization rather rather than computing a gradient. The dimension along
 which to descend is determined, at each step, by the variable flip that causes
@@ -216,7 +216,7 @@ Sample using both default and custom values of tenure and number of restarts.
 Tree Decomposition
 ------------------
 
-`Tree decomposition <https://en.wikipedia.org/wiki/Tree_decomposition>`_-based
+`Tree decomposition <https://en.wikipedia.org/wiki/Tree_decomposition>`__-based
 solvers have a runtime that is exponential in the
 `treewidth <https://en.wikipedia.org/wiki/Treewidth>`_ of the problem graph. For
 problems with low treewidth, the solver can find ground states very quickly.


### PR DESCRIPTION
#### Summary

Fix duplicate target name in README ReST.

PyPI uses `readme-renderer`, which used to fail (see [here](https://app.circleci.com/pipelines/github/dwavesystems/dwave-samplers/324/workflows/b47130d8-5d8a-4fe3-a1c3-b97c2f3827b3/jobs/10367)) when rendering readme
(long description) with:
```
<string>:34: (ERROR/3) Duplicate target name, cannot be used as a unique reference: "simulated annealing".
```

The fix was to use anonymous embedded URIs, as recommended in docutils [docs](https://www.docutils.org/docs/ref/rst/restructuredtext.html#anonymous-hyperlinks).


#### AI Generation Disclosure

ChatGPT was used to troubleshoot duplicate target name issue, and to recommend the use of anonymous links.