### PR TITLE
Use cibuildwheel 4.1.0 to build package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ commands:
     parameters:
       cibw-version:
         type: string
-        default: 3.4.0    # latest as of March 2026
+        default: 4.1.0    # latest as of July 2026
     steps:
       - run:
           name: run cibuildwheel

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -262,10 +262,15 @@ workflows:
             - build-and-test-linux
           matrix:
             parameters:
-              dependency-versions: [dimod==0.12.21 oldest-supported-numpy networkx==3.0, dimod numpy networkx]
+              dependency-versions: [dimod==0.12.21 numpy==2 networkx==3, dimod numpy networkx]
               # Skip some of the intermediate Python versions for speed
               python-version: ["3.10", "3.14"]
               only-binary: ["numpy,dimod,networkx"]
+            exclude:
+              # Python 3.14 doesn't support Numpy 2.0
+              - dependency-versions: "dimod==0.12.21 numpy==2 networkx==3"
+                python-version: "3.14"
+                only-binary: "numpy,dimod,networkx"
       - test-linux-cpp:
           filters: *tags
       - test-sdist:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ requires-python = ">=3.10"
 dependencies = [
     "dimod>=0.12.21,<0.13.0",  # oldest dimod that supports Python 3.14
     "networkx>=3,<4",
-    "numpy>=2,<3 ",   # oldest that supports Python 3.10
+    "numpy>=2,<3 ",
 ]
 
 [project.readme]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,8 +87,6 @@ test-command = "python -m unittest discover {project}/tests/"
 
 [tool.cibuildwheel.linux]
 archs = "x86_64 aarch64"
-manylinux-x86_64-image = "manylinux2014"
-manylinux-aarch64-image = "manylinux2014"
 
 [tool.cibuildwheel.macos]
 # We follow NumPy and don't build universal wheels, see https://github.com/numpy/numpy/pull/20787
@@ -104,11 +102,6 @@ repair-wheel-command = "delvewheel repair -w {dest_dir} {wheel} --namespace-pkg 
 # wheel. 313t and 314t do not support abi wheels yet.
 select = "cp31[!01]-*"  # uses fnmatch, will fail for 3.20+ but good enough for now
 build-frontend = { name = "build", args = ["-Csetup-args=-Dpython.allow_limited_api=true"] }
-inherit.repair-wheel-command = "append"
-repair-wheel-command = [
-    "pip install abi3audit",
-    "abi3audit --strict --report {wheel}",
-]
 
 # This is, by default, overriden in meson.build. We then override the override
 # in cibuildwheel. It's a bit convoluted, but (as of August 2025) it's the only

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ requires-python = ">=3.10"
 dependencies = [
     "dimod>=0.12.21,<0.13.0",  # oldest dimod that supports Python 3.14
     "networkx>=3,<4",
-    "numpy>=1.21.6,<3.0.0 ",   # oldest that supports Python 3.10
+    "numpy>=2,<3 ",   # oldest that supports Python 3.10
 ]
 
 [project.readme]

--- a/releasenotes/notes/cibuildwheel-4.1.0-8e52b6f184c6cb99.yaml
+++ b/releasenotes/notes/cibuildwheel-4.1.0-8e52b6f184c6cb99.yaml
@@ -1,0 +1,5 @@
+---
+upgrade:
+  - |
+    Let ``cibuildwheel`` determine the manylinux image type.
+    As of July 2026, the default is ``manylinux_2_28``.

--- a/releasenotes/notes/cibuildwheel-4.1.0-8e52b6f184c6cb99.yaml
+++ b/releasenotes/notes/cibuildwheel-4.1.0-8e52b6f184c6cb99.yaml
@@ -3,3 +3,4 @@ upgrade:
   - |
     Let ``cibuildwheel`` determine the manylinux image type.
     As of July 2026, the default is ``manylinux_2_28``.
+  - Require ``NumPy>=2``.


### PR DESCRIPTION
And use it to determine the default `manylinux` tag (currently `manylinux_2_28`)`.

#### AI Generation Disclosure
No AI used.