### PR TITLE
Feature/wolff-algorithm

### DIFF
--- a/dwave/samplers/sa/sampler.py
+++ b/dwave/samplers/sa/sampler.py
@@ -106,7 +106,7 @@ class SimulatedAnnealingSampler(dimod.Sampler, dimod.Initialized):
         beta_range
         beta_schedule
         beta_schedule_type
-        global_spin_flip_proposals
+        has_gsi_proposals
         initial_states
         initial_states_generator
         interrupt_function
@@ -116,8 +116,8 @@ class SimulatedAnnealingSampler(dimod.Sampler, dimod.Initialized):
         proposal_acceptance_criteria
         randomize_order
         seed
-        single_spin_flip_proposals
-        wolff_cluster_proposals
+        has_ss_proposals
+        has_wolff_proposals
         >>> sampler.parameters['beta_range']
         []
         >>> sampler.parameters['beta_schedule_type']
@@ -152,9 +152,9 @@ class SimulatedAnnealingSampler(dimod.Sampler, dimod.Initialized):
                            'initial_states_generator': [],
                            'randomize_order': [],
                            'proposal_acceptance_criteria': [],
-                           'single_spin_flip_proposals': [],
-                           'global_spin_flip_proposals': [],
-                           'wolff_cluster_proposals': [],
+                           'has_ss_proposals': [],
+                           'has_gsi_proposals': [],
+                           'has_wolff_proposals': [],
                            }
         self.properties = {'beta_schedule_options': ('linear', 'geometric',
                                                      'custom')}
@@ -172,9 +172,9 @@ class SimulatedAnnealingSampler(dimod.Sampler, dimod.Initialized):
                initial_states_generator: InitialStateGenerator = "random",
                randomize_order: bool = False,
                proposal_acceptance_criteria: str = 'Metropolis',
-               single_spin_flip_proposals: bool = True,
-               global_spin_flip_proposals: bool = False,
-               wolff_cluster_proposals: bool = False,
+               has_ss_proposals: bool = True,
+               has_gsi_proposals: bool = False,
+               has_wolff_proposals: bool = False,
                **kwargs) -> dimod.SampleSet:
         r"""Sample from a binary quadratic model.
 
@@ -277,24 +277,24 @@ class SimulatedAnnealingSampler(dimod.Sampler, dimod.Initialized):
                 When "Metropolis", each proposal is accepted according
                 to the Metropolis-Hastings criteria.
 
-            single_spin_flip_proposals:
-                When `True` (default), local single-spin updates are performed
+            has_ss_proposals:
+                When `True` (default), single-spin updates are proposed
                 in each sweep using the selected proposal acceptance criteria.
-                When `False`, spin flip proposals are not made.
+                When `False`, single-spin flip proposals are not made.
 
-            global_spin_flip_proposals:
-                When `True`, a global spin-inversion is
+            has_gsi_proposals:
+                When `True`, a global-spin-inversion update is
                 proposed per sweep. When `False` (default), no global inversion
                 proposals are applied. This move is non-ergodic with more than
                 1 spin and should typically be combined with
-                ``single_spin_flip_proposals``. This may accelerate mixing between
+                ``has_ss_proposals``. This may accelerate mixing between
                 nearly symmetric states at large Hamming distance (small
                 fields) relative to single spin flip proposals alone. When
                 enabled, the update follows single-spin proposals. Global spin
                 flip proposals are significantly less
-                costly per sweep than single-spin update proposals.
+                costly per sweep than the net cost of single-spin proposals.
 
-            wolff_cluster_proposals:
+            has_wolff_proposals:
                 When `True`, a Wolff cluster move is proposed per sweep. A
                 cluster grown from a random seed variable via satisfied bonds is
                 flipped subject to the Metropolis or Gibbs acceptance criteria.
@@ -302,8 +302,8 @@ class SimulatedAnnealingSampler(dimod.Sampler, dimod.Initialized):
                 enabled, the update follows single-spin proposals and global
                 inversion proposals, which can be disabled (for a standard
                 Wolff algorithm) by setting
-                ``single_spin_flip_proposals`` and
-                ``global_spin_flip_proposals`` to `False`.
+                ``has_ss_proposals`` and
+                ``has_gsi_proposals`` to `False`.
                 When appropriate, cluster proposals are typically significantly
                 more costly per sweep than single-spin update proposals. They
                 are known to scalably accelerate mixing in nearly unfrustrated
@@ -477,9 +477,9 @@ class SimulatedAnnealingSampler(dimod.Sampler, dimod.Initialized):
             num_sweeps_per_beta, beta_schedule,
             seed, initial_states_array,
             randomize_order, proposal_acceptance_criteria,
-            single_spin_flip_proposals,
-            global_spin_flip_proposals,
-            wolff_cluster_proposals,
+            has_ss_proposals,
+            has_gsi_proposals,
+            has_wolff_proposals,
             interrupt_function)
         timestamp_postprocess = perf_counter_ns()
 

--- a/dwave/samplers/sa/sampler.py
+++ b/dwave/samplers/sa/sampler.py
@@ -106,6 +106,7 @@ class SimulatedAnnealingSampler(dimod.Sampler, dimod.Initialized):
         beta_range
         beta_schedule
         beta_schedule_type
+        global_spin_flip
         initial_states
         initial_states_generator
         interrupt_function
@@ -149,6 +150,7 @@ class SimulatedAnnealingSampler(dimod.Sampler, dimod.Initialized):
                            'initial_states_generator': [],
                            'randomize_order': [],
                            'proposal_acceptance_criteria': [],
+                           'global_spin_flip': [],
                            }
         self.properties = {'beta_schedule_options': ('linear', 'geometric',
                                                      'custom')}
@@ -166,6 +168,7 @@ class SimulatedAnnealingSampler(dimod.Sampler, dimod.Initialized):
                initial_states_generator: InitialStateGenerator = "random",
                randomize_order: bool = False,
                proposal_acceptance_criteria: str = 'Metropolis',
+               global_spin_flip: bool = False,
                **kwargs) -> dimod.SampleSet:
         r"""Sample from a binary quadratic model.
 
@@ -264,6 +267,13 @@ class SimulatedAnnealingSampler(dimod.Sampler, dimod.Initialized):
                 to the Gibbs criteria.
                 When "Metropolis", each spin flip proposal is accepted according
                 to the Metropolis-Hastings criteria.
+
+            global_spin_flip:
+                When `True`, a global spin-inversion (Wolff-like) move is
+                proposed at the end of each sweep. This accelerates mixing
+                between nearly symmetric states at large Hamming distance (small
+                fields). When `False` (default), no global inversion move is
+                applied.
 
             interrupt_function (function, optional):
                 A function called with no parameters between each sample of
@@ -433,6 +443,7 @@ class SimulatedAnnealingSampler(dimod.Sampler, dimod.Initialized):
             num_sweeps_per_beta, beta_schedule,
             seed, initial_states_array,
             randomize_order, proposal_acceptance_criteria,
+            global_spin_flip,
             interrupt_function)
         timestamp_postprocess = perf_counter_ns()
 

--- a/dwave/samplers/sa/sampler.py
+++ b/dwave/samplers/sa/sampler.py
@@ -106,7 +106,7 @@ class SimulatedAnnealingSampler(dimod.Sampler, dimod.Initialized):
         beta_range
         beta_schedule
         beta_schedule_type
-        global_spin_flip
+        global_spin_flip_proposals
         initial_states
         initial_states_generator
         interrupt_function
@@ -116,7 +116,8 @@ class SimulatedAnnealingSampler(dimod.Sampler, dimod.Initialized):
         proposal_acceptance_criteria
         randomize_order
         seed
-        wolff_cluster_update
+        single_spin_flip_proposals
+        wolff_cluster_proposals
         >>> sampler.parameters['beta_range']
         []
         >>> sampler.parameters['beta_schedule_type']
@@ -151,8 +152,9 @@ class SimulatedAnnealingSampler(dimod.Sampler, dimod.Initialized):
                            'initial_states_generator': [],
                            'randomize_order': [],
                            'proposal_acceptance_criteria': [],
-                           'global_spin_flip': [],
-                           'wolff_cluster_update': [],
+                           'single_spin_flip_proposals': [],
+                           'global_spin_flip_proposals': [],
+                           'wolff_cluster_proposals': [],
                            }
         self.properties = {'beta_schedule_options': ('linear', 'geometric',
                                                      'custom')}
@@ -170,8 +172,9 @@ class SimulatedAnnealingSampler(dimod.Sampler, dimod.Initialized):
                initial_states_generator: InitialStateGenerator = "random",
                randomize_order: bool = False,
                proposal_acceptance_criteria: str = 'Metropolis',
-               global_spin_flip: bool = False,
-               wolff_cluster_update: bool = False,
+               single_spin_flip_proposals: bool = True,
+               global_spin_flip_proposals: bool = False,
+               wolff_cluster_proposals: bool = False,
                **kwargs) -> dimod.SampleSet:
         r"""Sample from a binary quadratic model.
 
@@ -252,39 +255,59 @@ class SimulatedAnnealingSampler(dimod.Sampler, dimod.Initialized):
                     states if fewer than ``num_reads`` or truncates if greater.
 
             randomize_order:
-                When `True`, each spin update selects a variable uniformly at random.
-                This method is ergodic, obeys detailed balance and preserves symmetries
-                of the model.
+                When `True`, each single-spin update selects a variable
+                uniformly at random. This method is ergodic, obeys detailed
+                balance, and preserves symmetries of the model.
 
-                When `False`, updates proceed sequentially through the labeled variables
-                on each sweep so that all variables are updated once per sweep. This method:
-
-                * can be non-ergodic in special cases when used with ``proposal_acceptance_critera=="Metropolis"``.
+                When `False`, single-spin updates proceed sequentially through
+                the labeled variables on each sweep so that all variables are
+                updated once per sweep. This method:
 
                 * can introduce a dynamical bias as a function of variable order.
 
-                * has faster per spin update than the True method.
+                * has faster per spin update than the `True` method.
+
+                * when used with ``proposal_acceptance_criteria=="Metropolis"``, 
+                  can be non-ergodic (or realize slow mixing dynamics) at (or
+                  approaching) zero and infinite temperature .
 
             proposal_acceptance_criteria:
-                When "Gibbs", each spin flip proposal is accepted according
+                When "Gibbs", each proposal is accepted according
                 to the Gibbs criteria.
-                When "Metropolis", each spin flip proposal is accepted according
+                When "Metropolis", each proposal is accepted according
                 to the Metropolis-Hastings criteria.
 
-            global_spin_flip:
-                When `True`, a global spin-inversion (Wolff-like) move is
-                proposed at the end of each sweep. This accelerates mixing
-                between nearly symmetric states at large Hamming distance (small
-                fields). When `False` (default), no global inversion move is
-                applied.
+            single_spin_flip_proposals:
+                When `True` (default), local single-spin updates are performed
+                in each sweep using the selected proposal acceptance criteria.
+                When `False`, spin flip proposals are not made.
 
-            wolff_cluster_update:
-                When `True`, a Wolff cluster move is proposed at the end of each
-                sweep. A cluster grown from a random seed variable via satisfied
-                bonds is flipped subject to the Metropolis or Gibbs acceptance
-                criteria. When `False` (default), no cluster move is applied. In
-                special circumstances the more efficient global_spin_flip option
-                can be used. 
+            global_spin_flip_proposals:
+                When `True`, a global spin-inversion is
+                proposed per sweep. When `False` (default), no global inversion
+                proposals are applied. This move is non-ergodic with more than
+                1 spin and should typically be combined with
+                ``single_spin_flip_proposals``. This may accelerate mixing between
+                nearly symmetric states at large Hamming distance (small
+                fields) relative to single spin flip proposals alone. When
+                enabled, the update follows single-spin proposals. Global spin
+                flip proposals are significantly less
+                costly per sweep than single-spin update proposals.
+
+            wolff_cluster_proposals:
+                When `True`, a Wolff cluster move is proposed per sweep. A
+                cluster grown from a random seed variable via satisfied bonds is
+                flipped subject to the Metropolis or Gibbs acceptance criteria.
+                When `False` (default), no cluster move is applied. When
+                enabled, the update follows single-spin proposals and global
+                inversion proposals, which can be disabled (for a standard
+                Wolff algorithm) by setting
+                ``single_spin_flip_proposals`` and
+                ``global_spin_flip_proposals`` to `False`.
+                When appropriate, cluster proposals are typically significantly
+                more costly per sweep than single-spin update proposals. They
+                are known to scalably accelerate mixing in nearly unfrustrated
+                models with small fields.
 
             interrupt_function (function, optional):
                 A function called with no parameters between each sample of
@@ -454,8 +477,9 @@ class SimulatedAnnealingSampler(dimod.Sampler, dimod.Initialized):
             num_sweeps_per_beta, beta_schedule,
             seed, initial_states_array,
             randomize_order, proposal_acceptance_criteria,
-            global_spin_flip,
-            wolff_cluster_update,
+            single_spin_flip_proposals,
+            global_spin_flip_proposals,
+            wolff_cluster_proposals,
             interrupt_function)
         timestamp_postprocess = perf_counter_ns()
 

--- a/dwave/samplers/sa/sampler.py
+++ b/dwave/samplers/sa/sampler.py
@@ -116,6 +116,7 @@ class SimulatedAnnealingSampler(dimod.Sampler, dimod.Initialized):
         proposal_acceptance_criteria
         randomize_order
         seed
+        wolff_cluster_update
         >>> sampler.parameters['beta_range']
         []
         >>> sampler.parameters['beta_schedule_type']
@@ -151,6 +152,7 @@ class SimulatedAnnealingSampler(dimod.Sampler, dimod.Initialized):
                            'randomize_order': [],
                            'proposal_acceptance_criteria': [],
                            'global_spin_flip': [],
+                           'wolff_cluster_update': [],
                            }
         self.properties = {'beta_schedule_options': ('linear', 'geometric',
                                                      'custom')}
@@ -169,6 +171,7 @@ class SimulatedAnnealingSampler(dimod.Sampler, dimod.Initialized):
                randomize_order: bool = False,
                proposal_acceptance_criteria: str = 'Metropolis',
                global_spin_flip: bool = False,
+               wolff_cluster_update: bool = False,
                **kwargs) -> dimod.SampleSet:
         r"""Sample from a binary quadratic model.
 
@@ -274,6 +277,14 @@ class SimulatedAnnealingSampler(dimod.Sampler, dimod.Initialized):
                 between nearly symmetric states at large Hamming distance (small
                 fields). When `False` (default), no global inversion move is
                 applied.
+
+            wolff_cluster_update:
+                When `True`, a Wolff cluster move is proposed at the end of each
+                sweep. A cluster grown from a random seed variable via satisfied
+                bonds is flipped subject to the Metropolis or Gibbs acceptance
+                criteria. When `False` (default), no cluster move is applied. In
+                special circumstances the more efficient global_spin_flip option
+                can be used. 
 
             interrupt_function (function, optional):
                 A function called with no parameters between each sample of
@@ -444,6 +455,7 @@ class SimulatedAnnealingSampler(dimod.Sampler, dimod.Initialized):
             seed, initial_states_array,
             randomize_order, proposal_acceptance_criteria,
             global_spin_flip,
+            wolff_cluster_update,
             interrupt_function)
         timestamp_postprocess = perf_counter_ns()
 

--- a/dwave/samplers/sa/simulated_annealing.pyx
+++ b/dwave/samplers/sa/simulated_annealing.pyx
@@ -38,6 +38,7 @@ cdef extern from "cpu_sa.h" namespace "dwave::samplers::sa":
             const unsigned long long seed,
             const VariableOrder varorder,
             const Proposal proposal_acceptance_criteria,
+            const bint global_spin_flip,
             callback interrupt_callback,
             void *interrupt_function) nogil
 
@@ -47,6 +48,7 @@ def simulated_annealing(num_samples, h, coupler_starts, coupler_ends,
                         np.ndarray[np.int8_t, ndim=2, mode="c"] states_numpy,
                         randomize_order=False,
                         proposal_acceptance_criteria='Metropolis',
+                        global_spin_flip=False,
                         interrupt_function=None):
     """Wraps `general_simulated_annealing` from `cpu_sa.cpp`. Accepts
     an Ising problem defined on a general graph and returns samples
@@ -118,6 +120,12 @@ def simulated_annealing(num_samples, h, coupler_starts, coupler_ends,
         When `Metropolis`, each spin flip proposal is accepted according to the
         Metropolis-Hastings criteria.
 
+    global_spin_flip: bool
+        When True, a global spin-inversion (Wolff-like) move is proposed at the
+        end of each sweep. This accelerates mixing between nearly symmetric
+        states at large Hamming distance (small ``h``). When False (default), no
+        global inversion move is applied.
+
     Returns
     -------
     samples : numpy.ndarray
@@ -162,6 +170,7 @@ def simulated_annealing(num_samples, h, coupler_starts, coupler_ends,
         _proposal_acceptance_criteria = Metropolis
     else:
         raise ValueError(f'Unknown proposal_acceptance_criteria: {proposal_acceptance_criteria}')
+    cdef bint _global_spin_flip = global_spin_flip
     cdef void* _interrupt_function
     if interrupt_function is None:
         _interrupt_function = NULL
@@ -182,6 +191,7 @@ def simulated_annealing(num_samples, h, coupler_starts, coupler_ends,
                                           _seed,
                                           _varorder,
                                           _proposal_acceptance_criteria,
+                                          _global_spin_flip,
                                           interrupt_callback,
                                           _interrupt_function)
 

--- a/dwave/samplers/sa/simulated_annealing.pyx
+++ b/dwave/samplers/sa/simulated_annealing.pyx
@@ -38,9 +38,9 @@ cdef extern from "cpu_sa.h" namespace "dwave::samplers::sa":
             const unsigned long long seed,
             const VariableOrder varorder,
             const Proposal proposal_acceptance_criteria,
-            const bint single_spin_flip_proposals,
-            const bint global_spin_flip_proposals,
-            const bint wolff_cluster_proposals,
+            const bint has_ss_proposals,
+            const bint has_gsi_proposals,
+            const bint has_wolff_proposals,
             callback interrupt_callback,
             void *interrupt_function) nogil
 
@@ -50,9 +50,9 @@ def simulated_annealing(num_samples, h, coupler_starts, coupler_ends,
                         np.ndarray[np.int8_t, ndim=2, mode="c"] states_numpy,
                         randomize_order=False,
                         proposal_acceptance_criteria='Metropolis',
-                        single_spin_flip_proposals=True,
-                        global_spin_flip_proposals=False,
-                        wolff_cluster_proposals=False,
+                        has_ss_proposals=True,
+                        has_gsi_proposals=False,
+                        has_wolff_proposals=False,
                         interrupt_function=None):
     """Wraps `general_simulated_annealing` from `cpu_sa.cpp`. Accepts
     an Ising problem defined on a general graph and returns samples
@@ -124,18 +124,18 @@ def simulated_annealing(num_samples, h, coupler_starts, coupler_ends,
         When `Metropolis`, each spin flip proposal is accepted according to the
         Metropolis-Hastings criteria.
 
-    single_spin_flip_proposals: bool
+    has_ss_proposals: bool
         When True (default), local single-spin updates are performed in each
         sweep using the selected proposal acceptance criteria. When False,
         local updates are disabled.
 
-    global_spin_flip_proposals: bool
+    has_gsi_proposals: bool
         When True, a global spin-inversion (Wolff-like) move is proposed at the
         end of each sweep. This accelerates mixing between nearly symmetric
         states at large Hamming distance (small ``h``). When False (default), no
         global inversion move is applied.
 
-    wolff_cluster_proposals: bool
+    has_wolff_proposals: bool
         When True, a Wolff cluster move is proposed at the end of each sweep. A
         cluster grown from a random seed variable via satisfied bonds is flipped
         subject to the Metropolis or Gibbs acceptance criteria. When False
@@ -185,9 +185,9 @@ def simulated_annealing(num_samples, h, coupler_starts, coupler_ends,
         _proposal_acceptance_criteria = Metropolis
     else:
         raise ValueError(f'Unknown proposal_acceptance_criteria: {proposal_acceptance_criteria}')
-    cdef bint _single_spin_flip_proposals = single_spin_flip_proposals
-    cdef bint _global_spin_flip_proposals = global_spin_flip_proposals
-    cdef bint _wolff_cluster_proposals = wolff_cluster_proposals
+    cdef bint _has_ss_proposals = has_ss_proposals
+    cdef bint _has_gsi_proposals = has_gsi_proposals
+    cdef bint _has_wolff_proposals = has_wolff_proposals
     cdef void* _interrupt_function
     if interrupt_function is None:
         _interrupt_function = NULL
@@ -208,9 +208,9 @@ def simulated_annealing(num_samples, h, coupler_starts, coupler_ends,
                                           _seed,
                                           _varorder,
                                           _proposal_acceptance_criteria,
-                                          _single_spin_flip_proposals,
-                                          _global_spin_flip_proposals,
-                                          _wolff_cluster_proposals,
+                                          _has_ss_proposals,
+                                          _has_gsi_proposals,
+                                          _has_wolff_proposals,
                                           interrupt_callback,
                                           _interrupt_function)
 

--- a/dwave/samplers/sa/simulated_annealing.pyx
+++ b/dwave/samplers/sa/simulated_annealing.pyx
@@ -39,6 +39,7 @@ cdef extern from "cpu_sa.h" namespace "dwave::samplers::sa":
             const VariableOrder varorder,
             const Proposal proposal_acceptance_criteria,
             const bint global_spin_flip,
+            const bint wolff_cluster_update,
             callback interrupt_callback,
             void *interrupt_function) nogil
 
@@ -49,6 +50,7 @@ def simulated_annealing(num_samples, h, coupler_starts, coupler_ends,
                         randomize_order=False,
                         proposal_acceptance_criteria='Metropolis',
                         global_spin_flip=False,
+                        wolff_cluster_update=False,
                         interrupt_function=None):
     """Wraps `general_simulated_annealing` from `cpu_sa.cpp`. Accepts
     an Ising problem defined on a general graph and returns samples
@@ -126,6 +128,12 @@ def simulated_annealing(num_samples, h, coupler_starts, coupler_ends,
         states at large Hamming distance (small ``h``). When False (default), no
         global inversion move is applied.
 
+    wolff_cluster_update: bool
+        When True, a Wolff cluster move is proposed at the end of each sweep. A
+        cluster grown from a random seed variable via satisfied bonds is flipped
+        subject to the Metropolis or Gibbs acceptance criteria. When False
+        (default), no cluster move is applied.
+
     Returns
     -------
     samples : numpy.ndarray
@@ -171,6 +179,7 @@ def simulated_annealing(num_samples, h, coupler_starts, coupler_ends,
     else:
         raise ValueError(f'Unknown proposal_acceptance_criteria: {proposal_acceptance_criteria}')
     cdef bint _global_spin_flip = global_spin_flip
+    cdef bint _wolff_cluster_update = wolff_cluster_update
     cdef void* _interrupt_function
     if interrupt_function is None:
         _interrupt_function = NULL
@@ -192,6 +201,7 @@ def simulated_annealing(num_samples, h, coupler_starts, coupler_ends,
                                           _varorder,
                                           _proposal_acceptance_criteria,
                                           _global_spin_flip,
+                                          _wolff_cluster_update,
                                           interrupt_callback,
                                           _interrupt_function)
 

--- a/dwave/samplers/sa/simulated_annealing.pyx
+++ b/dwave/samplers/sa/simulated_annealing.pyx
@@ -38,8 +38,9 @@ cdef extern from "cpu_sa.h" namespace "dwave::samplers::sa":
             const unsigned long long seed,
             const VariableOrder varorder,
             const Proposal proposal_acceptance_criteria,
-            const bint global_spin_flip,
-            const bint wolff_cluster_update,
+            const bint single_spin_flip_proposals,
+            const bint global_spin_flip_proposals,
+            const bint wolff_cluster_proposals,
             callback interrupt_callback,
             void *interrupt_function) nogil
 
@@ -49,8 +50,9 @@ def simulated_annealing(num_samples, h, coupler_starts, coupler_ends,
                         np.ndarray[np.int8_t, ndim=2, mode="c"] states_numpy,
                         randomize_order=False,
                         proposal_acceptance_criteria='Metropolis',
-                        global_spin_flip=False,
-                        wolff_cluster_update=False,
+                        single_spin_flip_proposals=True,
+                        global_spin_flip_proposals=False,
+                        wolff_cluster_proposals=False,
                         interrupt_function=None):
     """Wraps `general_simulated_annealing` from `cpu_sa.cpp`. Accepts
     an Ising problem defined on a general graph and returns samples
@@ -122,13 +124,18 @@ def simulated_annealing(num_samples, h, coupler_starts, coupler_ends,
         When `Metropolis`, each spin flip proposal is accepted according to the
         Metropolis-Hastings criteria.
 
-    global_spin_flip: bool
+    single_spin_flip_proposals: bool
+        When True (default), local single-spin updates are performed in each
+        sweep using the selected proposal acceptance criteria. When False,
+        local updates are disabled.
+
+    global_spin_flip_proposals: bool
         When True, a global spin-inversion (Wolff-like) move is proposed at the
         end of each sweep. This accelerates mixing between nearly symmetric
         states at large Hamming distance (small ``h``). When False (default), no
         global inversion move is applied.
 
-    wolff_cluster_update: bool
+    wolff_cluster_proposals: bool
         When True, a Wolff cluster move is proposed at the end of each sweep. A
         cluster grown from a random seed variable via satisfied bonds is flipped
         subject to the Metropolis or Gibbs acceptance criteria. When False
@@ -178,8 +185,9 @@ def simulated_annealing(num_samples, h, coupler_starts, coupler_ends,
         _proposal_acceptance_criteria = Metropolis
     else:
         raise ValueError(f'Unknown proposal_acceptance_criteria: {proposal_acceptance_criteria}')
-    cdef bint _global_spin_flip = global_spin_flip
-    cdef bint _wolff_cluster_update = wolff_cluster_update
+    cdef bint _single_spin_flip_proposals = single_spin_flip_proposals
+    cdef bint _global_spin_flip_proposals = global_spin_flip_proposals
+    cdef bint _wolff_cluster_proposals = wolff_cluster_proposals
     cdef void* _interrupt_function
     if interrupt_function is None:
         _interrupt_function = NULL
@@ -200,8 +208,9 @@ def simulated_annealing(num_samples, h, coupler_starts, coupler_ends,
                                           _seed,
                                           _varorder,
                                           _proposal_acceptance_criteria,
-                                          _global_spin_flip,
-                                          _wolff_cluster_update,
+                                          _single_spin_flip_proposals,
+                                          _global_spin_flip_proposals,
+                                          _wolff_cluster_proposals,
                                           interrupt_callback,
                                           _interrupt_function)
 

--- a/dwave/samplers/sa/src/cpu_sa.cpp
+++ b/dwave/samplers/sa/src/cpu_sa.cpp
@@ -104,6 +104,12 @@ double get_all_flip_energy(
 //        `beta_schedule`.
 // @param beta_schedule A list of the beta values to run `sweeps_per_beta`
 //        sweeps at.
+// @param single_spin_flip_proposals A boolean that indicates whether single spin-flip
+//        updates should be performed.
+// @param global_spin_flip_proposals A boolean that indicates whether global spin flip
+//        updates should be performed.
+// @param wolff_cluster_proposals A boolean that indicates whether Wolff cluster
+//        updates should be performed.
 // @return Nothing, but `state` now contains the result of the run.
 template <VariableOrder varorder, Proposal proposal_acceptance_criteria>
 void simulated_annealing_run(
@@ -114,8 +120,9 @@ void simulated_annealing_run(
     const vector<vector<double>>& neighbour_couplings,
     const int sweeps_per_beta,
     const vector<double>& beta_schedule,
-    const bool global_spin_flip,
-    const bool wolff_cluster_update
+    const bool single_spin_flip_proposals,
+    const bool global_spin_flip_proposals,
+    const bool wolff_cluster_proposals
 ) {
     const int num_vars = h.size();
 
@@ -135,12 +142,16 @@ void simulated_annealing_run(
     cluster_stack.reserve(num_vars);
 
     // build the delta_energy array by getting the delta energy for each
-    // variable
+    // variable, this could be conditional on single_spin_flip_proposals, but the benefit is negligible
     for (int var = 0; var < num_vars; var++) {
         delta_energy[var] = get_flip_energy(var, state, h, degrees,
                                             neighbors, neighbour_couplings);
     }
+    // Calculate energy change from a global_spin_flip_proposals, could
+    // be conditional, but the benefit is negligible
+
     double all_flip_energy = get_all_flip_energy(state, h);
+
     bool flip_spin;
     // perform the sweeps
     for (int beta_idx = 0; beta_idx < (int)beta_schedule.size(); beta_idx++) {
@@ -154,73 +165,75 @@ void simulated_annealing_run(
             // 1 / 2^64. since log(1 / 2^64) = -44.361, if the delta energy is
             // greater than 44.361 / beta, then we can safely skip computing
             // the probability.
-            const double threshold = 44.36142 / beta;
-            for (int varI = 0; varI < num_vars; varI++) {
-                int var;
-                if constexpr (varorder == Random) {
-                    FASTRAND(rand);
-                    var = rand%num_vars;
-                } else {
-                    var = varI;
-                }
-                if (delta_energy[var] >= threshold) continue;
-
-                flip_spin = false;
-
-                if constexpr (proposal_acceptance_criteria == Metropolis) {
-                    // Metropolis-Hastings acceptance rule
-                    if (delta_energy[var] <= 0.0) {
-                        // automatically accept any flip that results in a lower
-                        // energy
-                        flip_spin = true;
-                    } else {
-                        // get a random number, storing it in rand
+            if (single_spin_flip_proposals) {
+                const double threshold = 44.36142 / beta;
+                for (int varI = 0; varI < num_vars; varI++) {
+                    int var;
+                    if constexpr (varorder == Random) {
                         FASTRAND(rand);
-                        // accept the flip if exp(-delta_energy*beta) > random(0, 1)
-                        if (exp(-delta_energy[var]*beta) * RANDMAX > rand) {
+                        var = rand%num_vars;
+                    } else {
+                        var = varI;
+                    }
+                    if (delta_energy[var] >= threshold) continue;
+
+                    flip_spin = false;
+
+                    if constexpr (proposal_acceptance_criteria == Metropolis) {
+                        // Metropolis-Hastings acceptance rule
+                        if (delta_energy[var] <= 0.0) {
+                            // automatically accept any flip that results in a lower
+                            // energy
+                            flip_spin = true;
+                        } else {
+                            // get a random number, storing it in rand
+                            FASTRAND(rand);
+                            // accept the flip if exp(-delta_energy*beta) > random(0, 1)
+                            if (exp(-delta_energy[var]*beta) * RANDMAX > rand) {
+                                flip_spin = true;
+                            }
+                        }
+                    }
+                    else {
+                        // Gibbs update: Sample fairly from the two available states,
+                        // independent of the current value
+                        FASTRAND(rand);
+                        if (RANDMAX > rand * (1+exp(delta_energy[var]*beta))) {
                             flip_spin = true;
                         }
                     }
-                }
-                else {
-                    // Gibbs update: Sample fairly from the two available states,
-                    // independent of the current value
-                    FASTRAND(rand);
-                    if (RANDMAX > rand * (1+exp(delta_energy[var]*beta))) {
-                        flip_spin = true;
-                    }
-                }
 
-                if (flip_spin) {
-                    // since we have accepted the spin flip of variable `var`,
-                    // we need to adjust the delta energies of all the
-                    // neighboring variables
-                    const std::int8_t multiplier = 4 * state[var];
-                    // iterate over the neighbors of `var`
-                    for (int n_i = 0; n_i < degrees[var]; n_i++) {
-                        int neighbor = neighbors[var][n_i];
-                        // adjust the delta energy by
-                        // 4 * `var` state * coupler weight * neighbor state
-                        // the 4 is because the original contribution from
-                        // `var` to the neighbor's delta energy was
-                        // 2 * `var` state * coupler weight * neighbor state,
-                        // so since we are flipping `var`'s state, we need to
-                        // multiply it again by 2 to get the full offset.
-                        delta_energy[neighbor] += multiplier *
-                            neighbour_couplings[var][n_i] * state[neighbor];
-                    }
+                    if (flip_spin) {
+                        // since we have accepted the spin flip of variable `var`,
+                        // we need to adjust the delta energies of all the
+                        // neighboring variables
+                        const std::int8_t multiplier = 4 * state[var];
+                        // iterate over the neighbors of `var`
+                        for (int n_i = 0; n_i < degrees[var]; n_i++) {
+                            int neighbor = neighbors[var][n_i];
+                            // adjust the delta energy by
+                            // 4 * `var` state * coupler weight * neighbor state
+                            // the 4 is because the original contribution from
+                            // `var` to the neighbor's delta energy was
+                            // 2 * `var` state * coupler weight * neighbor state,
+                            // so since we are flipping `var`'s state, we need to
+                            // multiply it again by 2 to get the full offset.
+                            delta_energy[neighbor] += multiplier *
+                                neighbour_couplings[var][n_i] * state[neighbor];
+                        }
 
-                    // now we just need to flip its state and negate its delta
-                    // energy
-                    state[var] *= -1;
-                    delta_energy[var] *= -1;
-                    // update the whole-state inversion energy delta; state[var]
-                    // is the post-flip value, so the field contribution changes
-                    // by -4 * state[var] * h[var]
-                    all_flip_energy -= 4 * state[var] * h[var];
+                        // now we just need to flip its state and negate its delta
+                        // energy
+                        state[var] *= -1;
+                        delta_energy[var] *= -1;
+                        // update the whole-state inversion energy delta; state[var]
+                        // is the post-flip value, so the field contribution changes
+                        // by -4 * state[var] * h[var]
+                        all_flip_energy -= 4 * state[var] * h[var];
+                    }
                 }
             }
-            if (global_spin_flip) {
+            if (global_spin_flip_proposals) {
                 /*
                     Poor man's Wolff algorithm, but sufficient to
                     accelerate mixing for nearly symmetric states at large
@@ -238,7 +251,7 @@ void simulated_annealing_run(
                     }
                 }
             }
-            if (wolff_cluster_update) {
+            if (wolff_cluster_proposals) {
                 /*
                     Wolff cluster update. A cluster of spins is grown outward
                     from a uniformly selected seed variable: a satisfied bond,
@@ -313,7 +326,7 @@ void simulated_annealing_run(
                 }
                 
                 // TO DO: We should allow an option for Wolff to run without
-                // global_spin_flip, and single bit flips, in which case this
+                // global_spin_flip_proposals, and single bit flips, in which case this
                 // expensive stage can be skipped. Other efficiencies may
                 // also be possible.
                 if (flip_cluster) {
@@ -324,18 +337,21 @@ void simulated_annealing_run(
                     // recompute the single-flip delta energies for the cluster
                     // members and their neighbors, and refresh the global
                     // inversion energy, since many spins changed at once
-                    for (int ci = 0; ci < (int)cluster_members.size(); ci++) {
-                        int var = cluster_members[ci];
-                        delta_energy[var] = get_flip_energy(var, state, h, degrees,
-                                                            neighbors, neighbour_couplings);
-                        for (int n_i = 0; n_i < degrees[var]; n_i++) {
-                            int neighbor = neighbors[var][n_i];
-                            delta_energy[neighbor] = get_flip_energy(neighbor, state, h,
-                                degrees, neighbors, neighbour_couplings);
+                    if (single_spin_flip_proposals) {
+                        for (int ci = 0; ci < (int)cluster_members.size(); ci++) {
+                            int var = cluster_members[ci];
+                            delta_energy[var] = get_flip_energy(var, state, h, degrees,
+                                                                neighbors, neighbour_couplings);
+                            for (int n_i = 0; n_i < degrees[var]; n_i++) {
+                                int neighbor = neighbors[var][n_i];
+                                delta_energy[neighbor] = get_flip_energy(neighbor, state, h,
+                                    degrees, neighbors, neighbour_couplings);
+                            }
                         }
                     }
-                    if(global_spin_flip):
+                    if (global_spin_flip_proposals) {
                         all_flip_energy = get_all_flip_energy(state, h);
+                    }
                 }
 
                 // clear the cluster membership marks for the next sweep
@@ -399,10 +415,12 @@ double get_state_energy(
 //        `beta_schedule`.
 // @param beta_schedule A list of the beta values to run `sweeps_per_beta`
 //        sweeps at.
-// @param global_spin_flip When true, a global spin-inversion (Wolff-like) move is
+// @param single_spin_flip_proposals When true, single spin-flip updates are proposed
+//        throughout each sweep.
+// @param global_spin_flip_proposals When true, a global spin-inversion (Wolff-like) move is
 //        proposed at the end of every sweep to accelerate mixing between
 //        nearly symmetric states.
-// @param wolff_cluster_update When true, a Wolff cluster move is proposed at the
+// @param wolff_cluster_proposals When true, a Wolff cluster move is proposed at the
 //        end of every sweep: a cluster grown from a random seed via satisfied
 //        bonds is flipped subject to the Metropolis or Gibbs acceptance rule.
 // @param interrupt_callback A function that is invoked between each run of simulated annealing
@@ -422,8 +440,9 @@ int general_simulated_annealing(
     const uint64_t seed,
     const VariableOrder varorder,
     const Proposal proposal_acceptance_criteria,
-    const bool global_spin_flip,
-    const bool wolff_cluster_update,
+    const bool single_spin_flip_proposals,
+    const bool global_spin_flip_proposals,
+    const bool wolff_cluster_proposals,
     callback interrupt_callback,
     void * const interrupt_function
 ) {
@@ -486,30 +505,34 @@ int general_simulated_annealing(
         std::int8_t *state = states + sample*num_vars;
         // then do the actual sample. this function will modify state, storing
         // the sample there
-	// Branching here is designed to make expicit compile time optimizations
+        // Branching here is designed to make explicit compile time optimizations
         if (varorder == Random) {
             if (proposal_acceptance_criteria == Metropolis) {
                 simulated_annealing_run<Random, Metropolis>(state, h, degrees,
                                                     neighbors, neighbour_couplings,
                                                     sweeps_per_beta, beta_schedule,
-                                                    global_spin_flip, wolff_cluster_update);
+                                                    single_spin_flip_proposals,
+                                                    global_spin_flip_proposals, wolff_cluster_proposals);
             } else {
                 simulated_annealing_run<Random, Gibbs>(state, h, degrees,
                                                      neighbors, neighbour_couplings,
                                                      sweeps_per_beta, beta_schedule,
-                                                     global_spin_flip, wolff_cluster_update);
+                                                     single_spin_flip_proposals,
+                                                     global_spin_flip_proposals, wolff_cluster_proposals);
           }
         } else {
             if (proposal_acceptance_criteria == Metropolis) {
                 simulated_annealing_run<Sequential, Metropolis>(state, h, degrees,
                                                      neighbors, neighbour_couplings,
                                                      sweeps_per_beta, beta_schedule,
-                                                     global_spin_flip, wolff_cluster_update);
+                                                     single_spin_flip_proposals,
+                                                     global_spin_flip_proposals, wolff_cluster_proposals);
             } else {
                 simulated_annealing_run<Sequential, Gibbs>(state, h, degrees,
                                                       neighbors, neighbour_couplings,
                                                       sweeps_per_beta, beta_schedule,
-                                                      global_spin_flip, wolff_cluster_update);
+                                                      single_spin_flip_proposals,
+                                                      global_spin_flip_proposals, wolff_cluster_proposals);
             }
         }
         // compute the energy of the sample and store it in `energies`

--- a/dwave/samplers/sa/src/cpu_sa.cpp
+++ b/dwave/samplers/sa/src/cpu_sa.cpp
@@ -73,6 +73,21 @@ double get_flip_energy(
     return -2 * state[var] * energy;
 }
 
+// Returns the energy delta from flipping all variables
+// @param state the current state of all variables
+// @param h vector of h or field value on each variable
+// @return delta energy
+double get_all_flip_energy(
+    std::int8_t *state,
+    const vector<double>& h
+) {
+    double all_flip_energy = 0.0;
+    for (int var = 0; var < h.size(); var++) {
+        all_flip_energy += h[var] * state[var];
+    }
+    return -2 * all_flip_energy;
+}
+
 // Performs a single run of simulated annealing with the given inputs.
 // @param state a int8 array where each int8 holds the state of a
 //        variable. Note that this will be used as the initial state of the
@@ -98,7 +113,8 @@ void simulated_annealing_run(
     const vector<vector<int>>& neighbors,
     const vector<vector<double>>& neighbour_couplings,
     const int sweeps_per_beta,
-    const vector<double>& beta_schedule
+    const vector<double>& beta_schedule,
+    const bool global_spin_flip
 ) {
     const int num_vars = h.size();
 
@@ -114,7 +130,7 @@ void simulated_annealing_run(
         delta_energy[var] = get_flip_energy(var, state, h, degrees,
                                             neighbors, neighbour_couplings);
     }
-
+    double all_flip_energy = get_all_flip_energy(state, h);
     bool flip_spin;
     // perform the sweeps
     for (int beta_idx = 0; beta_idx < (int)beta_schedule.size(); beta_idx++) {
@@ -188,6 +204,28 @@ void simulated_annealing_run(
                     // energy
                     state[var] *= -1;
                     delta_energy[var] *= -1;
+                    // update the whole-state inversion energy delta; state[var]
+                    // is the post-flip value, so the field contribution changes
+                    // by -4 * state[var] * h[var]
+                    all_flip_energy -= 4 * state[var] * h[var];
+                }
+            }
+            if (global_spin_flip) {
+                /*
+                    Poor man's Wolff algorithm, but sufficient to
+                    accelerate mixing for nearly symmetric states at large
+                    Hamming distance (small h). Proposed once per sweep.
+                */
+                FASTRAND(rand);
+                if (RANDMAX > rand * (1+exp(all_flip_energy*beta))) {
+                    all_flip_energy *= -1;
+                    for (int var = 0; var < num_vars; var++) {
+                        state[var] *= -1;
+                        // under a global flip the coupling terms of delta_energy are
+                        // unchanged; only the field term flips, giving a net change
+                        // of -4 * state[var] * h[var] (state[var] post-flip)
+                        delta_energy[var] -= 4 * state[var] * h[var];
+                    }
                 }
             }
         }
@@ -246,6 +284,9 @@ double get_state_energy(
 //        `beta_schedule`.
 // @param beta_schedule A list of the beta values to run `sweeps_per_beta`
 //        sweeps at.
+// @param global_spin_flip When true, a global spin-inversion (Wolff-like) move is
+//        proposed at the end of every sweep to accelerate mixing between
+//        nearly symmetric states.
 // @param interrupt_callback A function that is invoked between each run of simulated annealing
 //        if the function returns True then it will stop running.
 // @param interrupt_function A pointer to contents that are passed to interrupt_callback.
@@ -263,6 +304,7 @@ int general_simulated_annealing(
     const uint64_t seed,
     const VariableOrder varorder,
     const Proposal proposal_acceptance_criteria,
+    const bool global_spin_flip,
     callback interrupt_callback,
     void * const interrupt_function
 ) {
@@ -330,21 +372,25 @@ int general_simulated_annealing(
             if (proposal_acceptance_criteria == Metropolis) {
                 simulated_annealing_run<Random, Metropolis>(state, h, degrees,
                                                     neighbors, neighbour_couplings,
-                                                    sweeps_per_beta, beta_schedule);
+                                                    sweeps_per_beta, beta_schedule,
+                                                    global_spin_flip);
             } else {
                 simulated_annealing_run<Random, Gibbs>(state, h, degrees,
                                                      neighbors, neighbour_couplings,
-                                                     sweeps_per_beta, beta_schedule);
+                                                     sweeps_per_beta, beta_schedule,
+                                                     global_spin_flip);
           }
         } else {
             if (proposal_acceptance_criteria == Metropolis) {
                 simulated_annealing_run<Sequential, Metropolis>(state, h, degrees,
                                                      neighbors, neighbour_couplings,
-                                                     sweeps_per_beta, beta_schedule);
+                                                     sweeps_per_beta, beta_schedule,
+                                                     global_spin_flip);
             } else {
                 simulated_annealing_run<Sequential, Gibbs>(state, h, degrees,
                                                       neighbors, neighbour_couplings,
-                                                      sweeps_per_beta, beta_schedule);
+                                                      sweeps_per_beta, beta_schedule,
+                                                      global_spin_flip);
             }
         }
         // compute the energy of the sample and store it in `energies`

--- a/dwave/samplers/sa/src/cpu_sa.cpp
+++ b/dwave/samplers/sa/src/cpu_sa.cpp
@@ -104,11 +104,11 @@ double get_all_flip_energy(
 //        `beta_schedule`.
 // @param beta_schedule A list of the beta values to run `sweeps_per_beta`
 //        sweeps at.
-// @param single_spin_flip_proposals A boolean that indicates whether single spin-flip
+// @param has_ss_proposals A boolean that indicates whether single spin-flip
 //        updates should be performed.
-// @param global_spin_flip_proposals A boolean that indicates whether global spin flip
+// @param has_gsi_proposals A boolean that indicates whether global spin flip
 //        updates should be performed.
-// @param wolff_cluster_proposals A boolean that indicates whether Wolff cluster
+// @param has_wolff_proposals A boolean that indicates whether Wolff cluster
 //        updates should be performed.
 // @return Nothing, but `state` now contains the result of the run.
 template <VariableOrder varorder, Proposal proposal_acceptance_criteria>
@@ -120,9 +120,9 @@ void simulated_annealing_run(
     const vector<vector<double>>& neighbour_couplings,
     const int sweeps_per_beta,
     const vector<double>& beta_schedule,
-    const bool single_spin_flip_proposals,
-    const bool global_spin_flip_proposals,
-    const bool wolff_cluster_proposals
+    const bool has_ss_proposals,
+    const bool has_gsi_proposals,
+    const bool has_wolff_proposals
 ) {
     const int num_vars = h.size();
 
@@ -142,12 +142,12 @@ void simulated_annealing_run(
     cluster_stack.reserve(num_vars);
 
     // build the delta_energy array by getting the delta energy for each
-    // variable, this could be conditional on single_spin_flip_proposals, but the benefit is negligible
+    // variable, this could be conditional on has_ss_proposals, but the benefit is negligible
     for (int var = 0; var < num_vars; var++) {
         delta_energy[var] = get_flip_energy(var, state, h, degrees,
                                             neighbors, neighbour_couplings);
     }
-    // Calculate energy change from a global_spin_flip_proposals, could
+    // Calculate energy change from a has_gsi_proposals, could
     // be conditional, but the benefit is negligible
 
     double all_flip_energy = get_all_flip_energy(state, h);
@@ -165,7 +165,7 @@ void simulated_annealing_run(
             // 1 / 2^64. since log(1 / 2^64) = -44.361, if the delta energy is
             // greater than 44.361 / beta, then we can safely skip computing
             // the probability.
-            if (single_spin_flip_proposals) {
+            if (has_ss_proposals) {
                 const double threshold = 44.36142 / beta;
                 for (int varI = 0; varI < num_vars; varI++) {
                     int var;
@@ -233,7 +233,7 @@ void simulated_annealing_run(
                     }
                 }
             }
-            if (global_spin_flip_proposals) {
+            if (has_gsi_proposals) {
                 /*
                     Poor man's Wolff algorithm, but sufficient to
                     accelerate mixing for nearly symmetric states at large
@@ -251,7 +251,7 @@ void simulated_annealing_run(
                     }
                 }
             }
-            if (wolff_cluster_proposals) {
+            if (has_wolff_proposals) {
                 /*
                     Wolff cluster update. A cluster of spins is grown outward
                     from a uniformly selected seed variable: a satisfied bond,
@@ -326,7 +326,7 @@ void simulated_annealing_run(
                 }
                 
                 // TO DO: We should allow an option for Wolff to run without
-                // global_spin_flip_proposals, and single bit flips, in which case this
+                // has_gsi_proposals, and single bit flips, in which case this
                 // expensive stage can be skipped. Other efficiencies may
                 // also be possible.
                 if (flip_cluster) {
@@ -337,7 +337,7 @@ void simulated_annealing_run(
                     // recompute the single-flip delta energies for the cluster
                     // members and their neighbors, and refresh the global
                     // inversion energy, since many spins changed at once
-                    if (single_spin_flip_proposals) {
+                    if (has_ss_proposals) {
                         for (int ci = 0; ci < (int)cluster_members.size(); ci++) {
                             int var = cluster_members[ci];
                             delta_energy[var] = get_flip_energy(var, state, h, degrees,
@@ -349,7 +349,7 @@ void simulated_annealing_run(
                             }
                         }
                     }
-                    if (global_spin_flip_proposals) {
+                    if (has_gsi_proposals) {
                         all_flip_energy = get_all_flip_energy(state, h);
                     }
                 }
@@ -415,12 +415,12 @@ double get_state_energy(
 //        `beta_schedule`.
 // @param beta_schedule A list of the beta values to run `sweeps_per_beta`
 //        sweeps at.
-// @param single_spin_flip_proposals When true, single spin-flip updates are proposed
+// @param has_ss_proposals When true, single spin-flip updates are proposed
 //        throughout each sweep.
-// @param global_spin_flip_proposals When true, a global spin-inversion (Wolff-like) move is
+// @param has_gsi_proposals When true, a global spin-inversion (Wolff-like) move is
 //        proposed at the end of every sweep to accelerate mixing between
 //        nearly symmetric states.
-// @param wolff_cluster_proposals When true, a Wolff cluster move is proposed at the
+// @param has_wolff_proposals When true, a Wolff cluster move is proposed at the
 //        end of every sweep: a cluster grown from a random seed via satisfied
 //        bonds is flipped subject to the Metropolis or Gibbs acceptance rule.
 // @param interrupt_callback A function that is invoked between each run of simulated annealing
@@ -440,9 +440,9 @@ int general_simulated_annealing(
     const uint64_t seed,
     const VariableOrder varorder,
     const Proposal proposal_acceptance_criteria,
-    const bool single_spin_flip_proposals,
-    const bool global_spin_flip_proposals,
-    const bool wolff_cluster_proposals,
+    const bool has_ss_proposals,
+    const bool has_gsi_proposals,
+    const bool has_wolff_proposals,
     callback interrupt_callback,
     void * const interrupt_function
 ) {
@@ -511,28 +511,28 @@ int general_simulated_annealing(
                 simulated_annealing_run<Random, Metropolis>(state, h, degrees,
                                                     neighbors, neighbour_couplings,
                                                     sweeps_per_beta, beta_schedule,
-                                                    single_spin_flip_proposals,
-                                                    global_spin_flip_proposals, wolff_cluster_proposals);
+                                                    has_ss_proposals,
+                                                    has_gsi_proposals, has_wolff_proposals);
             } else {
                 simulated_annealing_run<Random, Gibbs>(state, h, degrees,
                                                      neighbors, neighbour_couplings,
                                                      sweeps_per_beta, beta_schedule,
-                                                     single_spin_flip_proposals,
-                                                     global_spin_flip_proposals, wolff_cluster_proposals);
+                                                     has_ss_proposals,
+                                                     has_gsi_proposals, has_wolff_proposals);
           }
         } else {
             if (proposal_acceptance_criteria == Metropolis) {
                 simulated_annealing_run<Sequential, Metropolis>(state, h, degrees,
                                                      neighbors, neighbour_couplings,
                                                      sweeps_per_beta, beta_schedule,
-                                                     single_spin_flip_proposals,
-                                                     global_spin_flip_proposals, wolff_cluster_proposals);
+                                                     has_ss_proposals,
+                                                     has_gsi_proposals, has_wolff_proposals);
             } else {
                 simulated_annealing_run<Sequential, Gibbs>(state, h, degrees,
                                                       neighbors, neighbour_couplings,
                                                       sweeps_per_beta, beta_schedule,
-                                                      single_spin_flip_proposals,
-                                                      global_spin_flip_proposals, wolff_cluster_proposals);
+                                                      has_ss_proposals,
+                                                      has_gsi_proposals, has_wolff_proposals);
             }
         }
         // compute the energy of the sample and store it in `energies`

--- a/dwave/samplers/sa/src/cpu_sa.cpp
+++ b/dwave/samplers/sa/src/cpu_sa.cpp
@@ -114,7 +114,8 @@ void simulated_annealing_run(
     const vector<vector<double>>& neighbour_couplings,
     const int sweeps_per_beta,
     const vector<double>& beta_schedule,
-    const bool global_spin_flip
+    const bool global_spin_flip,
+    const bool wolff_cluster_update
 ) {
     const int num_vars = h.size();
 
@@ -123,6 +124,15 @@ void simulated_annealing_run(
     double *delta_energy = (double*)malloc(num_vars * sizeof(double));
 
     uint64_t rand; // this will hold the value of the rng
+
+    // buffers reused by the Wolff cluster update below; `in_cluster` marks the
+    // variables currently in the growing cluster, while `cluster_members` and
+    // `cluster_stack` track the members and the growth frontier respectively
+    std::vector<char> in_cluster(num_vars, 0);
+    std::vector<int> cluster_members;
+    std::vector<int> cluster_stack;
+    cluster_members.reserve(num_vars);
+    cluster_stack.reserve(num_vars);
 
     // build the delta_energy array by getting the delta energy for each
     // variable
@@ -228,6 +238,111 @@ void simulated_annealing_run(
                     }
                 }
             }
+            if (wolff_cluster_update) {
+                /*
+                    Wolff cluster update. A cluster of spins is grown outward
+                    from a uniformly selected seed variable: a satisfied bond,
+                    for which neighbour_couplings[i][j] * state[i] * state[j] < 0,
+                    links its two variables into the same cluster with the Wolff
+                    bond probability p = 1 - exp(-2 * beta * |J_ij|). Flipping the
+                    whole cluster is then accepted according to the Metropolis or
+                    Gibbs criteria on the total energy change, which preserves
+                    detailed balance in the presence of local fields h.
+                */
+                FASTRAND(rand);
+                int seed = rand % num_vars;
+                cluster_members.clear();
+                cluster_stack.clear();
+                in_cluster[seed] = 1;
+                cluster_members.push_back(seed);
+                cluster_stack.push_back(seed);
+                while (!cluster_stack.empty()) {
+                    int var = cluster_stack.back();
+                    cluster_stack.pop_back();
+                    // try to grow the cluster across each incident bond
+                    for (int n_i = 0; n_i < degrees[var]; n_i++) {
+                        int neighbor = neighbors[var][n_i];
+                        if (in_cluster[neighbor]) continue;
+                        // probability of adding the neighbor to the cluster;
+                        // this is non-positive (and therefore never accepted)
+                        // for frustrated bonds where J_ij * s_i * s_j > 0
+                        double p_add = 1.0 - exp(2.0 * beta *
+                            neighbour_couplings[var][n_i] * state[var] * state[neighbor]);
+                        FASTRAND(rand);
+                        if (p_add * RANDMAX > rand) {
+                            in_cluster[neighbor] = 1;
+                            cluster_members.push_back(neighbor);
+                            cluster_stack.push_back(neighbor);
+                        }
+                    }
+                }
+
+                // energy change from flipping every spin in the cluster: the
+                // field term for each member plus the coupling terms that cross
+                // the cluster boundary (bonds internal to the cluster are
+                // unchanged when all their endpoints flip together)
+                double cluster_flip_energy = 0.0;
+                for (int ci = 0; ci < (int)cluster_members.size(); ci++) {
+                    int var = cluster_members[ci];
+                    cluster_flip_energy -= 2.0 * h[var] * state[var];
+                    for (int n_i = 0; n_i < degrees[var]; n_i++) {
+                        int neighbor = neighbors[var][n_i];
+                        if (in_cluster[neighbor]) continue;
+                        cluster_flip_energy -= 2.0 * neighbour_couplings[var][n_i]
+                            * state[var] * state[neighbor];
+                    }
+                }
+
+                bool flip_cluster = false;
+                if constexpr (proposal_acceptance_criteria == Metropolis) {
+                    // Metropolis-Hastings acceptance rule on the cluster flip
+                    if (cluster_flip_energy <= 0.0) {
+                        flip_cluster = true;
+                    } else {
+                        FASTRAND(rand);
+                        if (exp(-cluster_flip_energy * beta) * RANDMAX > rand) {
+                            flip_cluster = true;
+                        }
+                    }
+                } else {
+                    // Gibbs acceptance rule on the cluster flip
+                    FASTRAND(rand);
+                    if (RANDMAX > rand * (1 + exp(cluster_flip_energy * beta))) {
+                        flip_cluster = true;
+                    }
+                }
+                
+                // TO DO: We should allow an option for Wolff to run without
+                // global_spin_flip, and single bit flips, in which case this
+                // expensive stage can be skipped. Other efficiencies may
+                // also be possible.
+                if (flip_cluster) {
+                    // flip every spin in the accepted cluster
+                    for (int ci = 0; ci < (int)cluster_members.size(); ci++) {
+                        state[cluster_members[ci]] *= -1;
+                    }
+                    // recompute the single-flip delta energies for the cluster
+                    // members and their neighbors, and refresh the global
+                    // inversion energy, since many spins changed at once
+                    for (int ci = 0; ci < (int)cluster_members.size(); ci++) {
+                        int var = cluster_members[ci];
+                        delta_energy[var] = get_flip_energy(var, state, h, degrees,
+                                                            neighbors, neighbour_couplings);
+                        for (int n_i = 0; n_i < degrees[var]; n_i++) {
+                            int neighbor = neighbors[var][n_i];
+                            delta_energy[neighbor] = get_flip_energy(neighbor, state, h,
+                                degrees, neighbors, neighbour_couplings);
+                        }
+                    }
+                    if(global_spin_flip):
+                        all_flip_energy = get_all_flip_energy(state, h);
+                }
+
+                // clear the cluster membership marks for the next sweep
+                for (int ci = 0; ci < (int)cluster_members.size(); ci++) {
+                    in_cluster[cluster_members[ci]] = 0;
+                }
+            }
         }
     }
 
@@ -287,6 +402,9 @@ double get_state_energy(
 // @param global_spin_flip When true, a global spin-inversion (Wolff-like) move is
 //        proposed at the end of every sweep to accelerate mixing between
 //        nearly symmetric states.
+// @param wolff_cluster_update When true, a Wolff cluster move is proposed at the
+//        end of every sweep: a cluster grown from a random seed via satisfied
+//        bonds is flipped subject to the Metropolis or Gibbs acceptance rule.
 // @param interrupt_callback A function that is invoked between each run of simulated annealing
 //        if the function returns True then it will stop running.
 // @param interrupt_function A pointer to contents that are passed to interrupt_callback.
@@ -305,6 +423,7 @@ int general_simulated_annealing(
     const VariableOrder varorder,
     const Proposal proposal_acceptance_criteria,
     const bool global_spin_flip,
+    const bool wolff_cluster_update,
     callback interrupt_callback,
     void * const interrupt_function
 ) {
@@ -373,24 +492,24 @@ int general_simulated_annealing(
                 simulated_annealing_run<Random, Metropolis>(state, h, degrees,
                                                     neighbors, neighbour_couplings,
                                                     sweeps_per_beta, beta_schedule,
-                                                    global_spin_flip);
+                                                    global_spin_flip, wolff_cluster_update);
             } else {
                 simulated_annealing_run<Random, Gibbs>(state, h, degrees,
                                                      neighbors, neighbour_couplings,
                                                      sweeps_per_beta, beta_schedule,
-                                                     global_spin_flip);
+                                                     global_spin_flip, wolff_cluster_update);
           }
         } else {
             if (proposal_acceptance_criteria == Metropolis) {
                 simulated_annealing_run<Sequential, Metropolis>(state, h, degrees,
                                                      neighbors, neighbour_couplings,
                                                      sweeps_per_beta, beta_schedule,
-                                                     global_spin_flip);
+                                                     global_spin_flip, wolff_cluster_update);
             } else {
                 simulated_annealing_run<Sequential, Gibbs>(state, h, degrees,
                                                       neighbors, neighbour_couplings,
                                                       sweeps_per_beta, beta_schedule,
-                                                      global_spin_flip);
+                                                      global_spin_flip, wolff_cluster_update);
             }
         }
         // compute the energy of the sample and store it in `energies`

--- a/dwave/samplers/sa/src/cpu_sa.h
+++ b/dwave/samplers/sa/src/cpu_sa.h
@@ -56,8 +56,9 @@ void simulated_annealing_run(
     const std::vector<std::vector<double>>& neighbour_couplings,
     const int sweeps_per_beta,
     const std::vector<double>& beta_schedule,
-    const bool global_spin_flip,
-    const bool wolff_cluster_update
+    const bool single_spin_flip_proposals,
+    const bool global_spin_flip_proposals,
+    const bool wolff_cluster_proposals
 );
 
 typedef bool (*const callback)(void * const function);
@@ -75,8 +76,9 @@ int general_simulated_annealing(
     const uint64_t seed,
     const VariableOrder varorder,
     const Proposal proposal_acceptance_criteria,
-    const bool global_spin_flip,
-    const bool wolff_cluster_update,
+    const bool single_spin_flip_proposals,
+    const bool global_spin_flip_proposals,
+    const bool wolff_cluster_proposals,
     callback interrupt_callback,
     void * const interrupt_function
 );

--- a/dwave/samplers/sa/src/cpu_sa.h
+++ b/dwave/samplers/sa/src/cpu_sa.h
@@ -56,7 +56,8 @@ void simulated_annealing_run(
     const std::vector<std::vector<double>>& neighbour_couplings,
     const int sweeps_per_beta,
     const std::vector<double>& beta_schedule,
-    const bool global_spin_flip
+    const bool global_spin_flip,
+    const bool wolff_cluster_update
 );
 
 typedef bool (*const callback)(void * const function);
@@ -75,6 +76,7 @@ int general_simulated_annealing(
     const VariableOrder varorder,
     const Proposal proposal_acceptance_criteria,
     const bool global_spin_flip,
+    const bool wolff_cluster_update,
     callback interrupt_callback,
     void * const interrupt_function
 );

--- a/dwave/samplers/sa/src/cpu_sa.h
+++ b/dwave/samplers/sa/src/cpu_sa.h
@@ -55,7 +55,8 @@ void simulated_annealing_run(
     const std::vector<std::vector<int>>& neighbors,
     const std::vector<std::vector<double>>& neighbour_couplings,
     const int sweeps_per_beta,
-    const std::vector<double>& beta_schedule
+    const std::vector<double>& beta_schedule,
+    const bool global_spin_flip
 );
 
 typedef bool (*const callback)(void * const function);
@@ -73,6 +74,7 @@ int general_simulated_annealing(
     const uint64_t seed,
     const VariableOrder varorder,
     const Proposal proposal_acceptance_criteria,
+    const bool global_spin_flip,
     callback interrupt_callback,
     void * const interrupt_function
 );

--- a/dwave/samplers/sa/src/cpu_sa.h
+++ b/dwave/samplers/sa/src/cpu_sa.h
@@ -56,9 +56,9 @@ void simulated_annealing_run(
     const std::vector<std::vector<double>>& neighbour_couplings,
     const int sweeps_per_beta,
     const std::vector<double>& beta_schedule,
-    const bool single_spin_flip_proposals,
-    const bool global_spin_flip_proposals,
-    const bool wolff_cluster_proposals
+    const bool has_ss_proposals,
+    const bool has_gsi_proposals,
+    const bool has_wolff_proposals
 );
 
 typedef bool (*const callback)(void * const function);
@@ -76,9 +76,9 @@ int general_simulated_annealing(
     const uint64_t seed,
     const VariableOrder varorder,
     const Proposal proposal_acceptance_criteria,
-    const bool single_spin_flip_proposals,
-    const bool global_spin_flip_proposals,
-    const bool wolff_cluster_proposals,
+    const bool has_ss_proposals,
+    const bool has_gsi_proposals,
+    const bool has_wolff_proposals,
     callback interrupt_callback,
     void * const interrupt_function
 );

--- a/tests/test_simulated_annealing.py
+++ b/tests/test_simulated_annealing.py
@@ -295,7 +295,7 @@ class TestSA(unittest.TestCase):
             "Initial states do not match samples with 0 sweeps",
         )
 
-    def test_single_spin_flip_proposals(self):
+    def test_has_ss_proposals(self):
         problem = self._sample_fm_problem(num_variables=8, num_samples=20, num_sweeps=10)
         (
             num_samples,
@@ -331,7 +331,7 @@ class TestSA(unittest.TestCase):
             beta_schedule,
             seed,
             np.copy(initial_states),
-            single_spin_flip_proposals=True,
+            has_ss_proposals=True,
         )
 
         self.assertTrue(np.array_equal(samples_default, samples_true))
@@ -347,7 +347,7 @@ class TestSA(unittest.TestCase):
             beta_schedule,
             seed,
             np.copy(initial_states),
-            single_spin_flip_proposals=False,
+            has_ss_proposals=False,
         )
 
         self.assertTrue(np.array_equal(initial_states, samples_false))

--- a/tests/test_simulated_annealing.py
+++ b/tests/test_simulated_annealing.py
@@ -295,6 +295,63 @@ class TestSA(unittest.TestCase):
             "Initial states do not match samples with 0 sweeps",
         )
 
+    def test_single_spin_flip_proposals(self):
+        problem = self._sample_fm_problem(num_variables=8, num_samples=20, num_sweeps=10)
+        (
+            num_samples,
+            h,
+            coupler_starts,
+            coupler_ends,
+            coupler_weights,
+            sweeps_at_beta,
+            beta_schedule,
+            seed,
+            initial_states,
+        ) = problem
+
+        samples_default, energies_default = simulated_annealing(
+            num_samples,
+            h,
+            coupler_starts,
+            coupler_ends,
+            coupler_weights,
+            sweeps_at_beta,
+            beta_schedule,
+            seed,
+            np.copy(initial_states),
+        )
+
+        samples_true, energies_true = simulated_annealing(
+            num_samples,
+            h,
+            coupler_starts,
+            coupler_ends,
+            coupler_weights,
+            sweeps_at_beta,
+            beta_schedule,
+            seed,
+            np.copy(initial_states),
+            single_spin_flip_proposals=True,
+        )
+
+        self.assertTrue(np.array_equal(samples_default, samples_true))
+        self.assertTrue(np.array_equal(energies_default, energies_true))
+
+        samples_false, _ = simulated_annealing(
+            num_samples,
+            h,
+            coupler_starts,
+            coupler_ends,
+            coupler_weights,
+            sweeps_at_beta,
+            beta_schedule,
+            seed,
+            np.copy(initial_states),
+            single_spin_flip_proposals=False,
+        )
+
+        self.assertTrue(np.array_equal(initial_states, samples_false))
+
     @unittest.skipIf(NUM_CPUS < 4, "insufficient CPUs available")
     def test_concurrency(self):
         """Multiple SA run in parallel threads, not blocking each other due to GIL."""


### PR DESCRIPTION
Single-spin updates are slow to mix for unfrustrated or nearly unfrustrated models.
Some mixing time-scales can be significantly accelerated by the use of spin flip proposals, or cluster updates
This pull request implements both options as non-default options for the simulated annealing sampler.

This code includes tests, and has also been tested functionally in projects of interest.

#### AI Generation Disclosure

The wolff cluster update per sweep (contents of use_wolff_proposals clause in cpu_sa.cpp) was implemented using a guided prompt and then checked for accuracy.